### PR TITLE
Fix Netlify build errors

### DIFF
--- a/app/legacy/page.js
+++ b/app/legacy/page.js
@@ -2,6 +2,8 @@
 import { UserProvider, withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import LegacyApp from '../../legacy_core/app/app.js';
 
+export const dynamic = "force-dynamic";
+
 function LegacyCorePage() {
   return (
     <UserProvider>

--- a/next.config.js
+++ b/next.config.js
@@ -44,7 +44,7 @@ const nextConfig = {
 
   // Bundle optimization
   experimental: {
-    optimizeCss: true,
+    optimizeCss: false,
     optimizePackageImports: [
       '@heroicons/react',
       '@material-tailwind/react',


### PR DESCRIPTION
## Summary
- disable Next.js CSS optimization which uses `critters`
- mark the legacy page as dynamic so that `UserProvider` is not required during export

## Testing
- `npm test` *(fails: 4 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_b_686611be66888333a5608332b35184c9