### PR TITLE
Fix missing UserProvider and update tests

### DIFF
--- a/__tests__/HomePage.test.jsx
+++ b/__tests__/HomePage.test.jsx
@@ -1,20 +1,33 @@
 import { render, screen } from '@testing-library/react'
 import HomePage from '../app/page'
+import { AppModeProvider } from '../app/providers/AppModeProvider'
 
 describe('HomePage', () => {
   it('renders the LandingPage component', () => {
-    render(<HomePage />)
+    render(
+      <AppModeProvider>
+        <HomePage />
+      </AppModeProvider>
+    )
     expect(screen.getByText('Welcome to')).toBeInTheDocument()
-    expect(screen.getByText('SYMFARMIA')).toBeInTheDocument()
+    expect(screen.getAllByText('SYMFARMIA').length).toBeGreaterThan(0)
   })
 
   it('contains the main SYMFARMIA branding', () => {
-    render(<HomePage />)
+    render(
+      <AppModeProvider>
+        <HomePage />
+      </AppModeProvider>
+    )
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Welcome to SYMFARMIA')
   })
 
   it('displays the platform description', () => {
-    render(<HomePage />)
+    render(
+      <AppModeProvider>
+        <HomePage />
+      </AppModeProvider>
+    )
     expect(screen.getByText('Intelligent platform for independent doctors')).toBeInTheDocument()
   })
 })

--- a/__tests__/LandingPage.test.jsx
+++ b/__tests__/LandingPage.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import LandingPage from '../src/pages/LandingPage'
+import { AppModeProvider } from '../app/providers/AppModeProvider'
 
 // Mock window.alert
 window.alert = jest.fn()
@@ -10,55 +11,91 @@ describe('LandingPage', () => {
   })
 
   it('renders the main heading', () => {
-    render(<LandingPage />)
+    render(
+      <AppModeProvider>
+        <LandingPage />
+      </AppModeProvider>
+    )
     expect(screen.getByText('Welcome to')).toBeInTheDocument()
-    expect(screen.getByText('SYMFARMIA')).toBeInTheDocument()
+    expect(screen.getAllByText('SYMFARMIA').length).toBeGreaterThan(0)
   })
 
   it('renders the subtitle', () => {
-    render(<LandingPage />)
+    render(
+      <AppModeProvider>
+        <LandingPage />
+      </AppModeProvider>
+    )
     expect(screen.getByText('Intelligent platform for independent doctors')).toBeInTheDocument()
   })
 
   it('renders Login and Register buttons', () => {
-    render(<LandingPage />)
+    render(
+      <AppModeProvider>
+        <LandingPage />
+      </AppModeProvider>
+    )
     expect(screen.getByRole('link', { name: /login/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /register/i })).toBeInTheDocument()
   })
 
-  it('renders Explore Without Account button', () => {
-    render(<LandingPage />)
-    expect(screen.getByRole('button', { name: /explore without account/i })).toBeInTheDocument()
+  it('renders Try Demo Mode button', () => {
+    render(
+      <AppModeProvider>
+        <LandingPage />
+      </AppModeProvider>
+    )
+    expect(screen.getByRole('button', { name: /try demo mode/i })).toBeInTheDocument()
   })
 
-  it('shows alert when Explore Without Account is clicked', () => {
-    render(<LandingPage />)
-    const exploreButton = screen.getByRole('button', { name: /explore without account/i })
-    fireEvent.click(exploreButton)
-    expect(window.alert).toHaveBeenCalledWith('Demo functionality coming soon!')
+  it('opens the demo modal when Try Demo Mode is clicked', () => {
+    render(
+      <AppModeProvider>
+        <LandingPage />
+      </AppModeProvider>
+    )
+    const demoButton = screen.getByRole('button', { name: /try demo mode/i })
+    fireEvent.click(demoButton)
+    expect(screen.getByText('Demo Login')).toBeInTheDocument()
   })
 
   it('renders feature cards', () => {
-    render(<LandingPage />)
+    render(
+      <AppModeProvider>
+        <LandingPage />
+      </AppModeProvider>
+    )
     expect(screen.getByText('Patient Management')).toBeInTheDocument()
     expect(screen.getByText('Medical Reports')).toBeInTheDocument()
     expect(screen.getByText('Analytics')).toBeInTheDocument()
   })
 
   it('has correct Login link href', () => {
-    render(<LandingPage />)
+    render(
+      <AppModeProvider>
+        <LandingPage />
+      </AppModeProvider>
+    )
     const loginLink = screen.getByRole('link', { name: /login/i })
     expect(loginLink).toHaveAttribute('href', '/api/auth/login?returnTo=/legacy')
   })
 
   it('has correct Register link href', () => {
-    render(<LandingPage />)
+    render(
+      <AppModeProvider>
+        <LandingPage />
+      </AppModeProvider>
+    )
     const registerLink = screen.getByRole('link', { name: /register/i })
     expect(registerLink).toHaveAttribute('href', '/api/auth/login?returnTo=/legacy')
   })
 
   it('renders footer copyright', () => {
-    render(<LandingPage />)
+    render(
+      <AppModeProvider>
+        <LandingPage />
+      </AppModeProvider>
+    )
     expect(screen.getByText(/© 2024 SYMFARMIA/)).toBeInTheDocument()
   })
 })

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,6 +1,7 @@
 import './globals.css'
 import { Inter } from 'next/font/google'
 import ErrorBoundary from '../src/components/ErrorBoundary'
+import { UserProvider } from '@auth0/nextjs-auth0/client'
 import { AppModeProvider } from './providers/AppModeProvider'
 import DemoModeBanner from './components/DemoModeBanner'
 
@@ -16,10 +17,12 @@ export default function RootLayout({ children }) {
     <html lang="en">
       <body className={inter.className} style={{backgroundColor: "#F9FAFB"}}>
         <ErrorBoundary>
-          <AppModeProvider>
-            <DemoModeBanner />
-            {children}
-          </AppModeProvider>
+          <UserProvider>
+            <AppModeProvider>
+              <DemoModeBanner />
+              {children}
+            </AppModeProvider>
+          </UserProvider>
         </ErrorBoundary>
       </body>
     </html>

--- a/app/legacy/page.js
+++ b/app/legacy/page.js
@@ -1,18 +1,11 @@
 "use client"
-import { UserProvider, withPageAuthRequired } from '@auth0/nextjs-auth0/client';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 import LegacyApp from '../../legacy_core/app/app.js';
-import { AppModeProvider } from '../providers/AppModeProvider';
 
 export const dynamic = "force-dynamic";
 
 function LegacyCorePage() {
-  return (
-    <UserProvider>
-      <AppModeProvider>
-        <LegacyApp />
-      </AppModeProvider>
-    </UserProvider>
-  );
+  return <LegacyApp />;
 }
 
 // Protect this page - only authenticated users can access legacy core

--- a/legacy_core/app/page.js
+++ b/legacy_core/app/page.js
@@ -1,14 +1,9 @@
 "use client"
 import React from 'react';
-import { UserProvider } from '@auth0/nextjs-auth0/client'
 import App from './app';
 
 const Page = () => {
-  return (
-    <UserProvider>
-      <App></App>
-    </UserProvider>
-  );
+  return <App />;
 };
 
 export default Page;


### PR DESCRIPTION
## Summary
- wrap the entire app with `UserProvider` in the root layout
- simplify the legacy page component
- remove redundant provider wrapper in legacy core page
- update HomePage and LandingPage tests for new structure

## Testing
- `npm test` *(fails: SyntaxError in dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6866259b4ea883338507bcdcda8113c9