### PR TITLE
Wrap LandingPage in context provider

### DIFF
--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -4,9 +4,9 @@ import SmokeTest from '../components/SmokeTest';
 import Logger from '../utils/logger';
 import DemoLoginModal from '../../components/DemoLoginModal';
 import PatientManagementPreview from '../components/PatientManagementPreview';
-import { useAppMode } from '../../app/providers/AppModeProvider';
+import { AppModeProvider, useAppMode } from '../../app/providers/AppModeProvider';
 
-const LandingPage = () => {
+const LandingPageContent = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isPatientPreviewOpen, setIsPatientPreviewOpen] = useState(false);
   const { isDemoMode } = useAppMode();
@@ -168,5 +168,11 @@ const LandingPage = () => {
     </div>
   );
 };
+
+const LandingPage = () => (
+  <AppModeProvider>
+    <LandingPageContent />
+  </AppModeProvider>
+);
 
 export default LandingPage;


### PR DESCRIPTION
## Summary
- ensure `LandingPage` is wrapped in `AppModeProvider` so `useAppMode` is valid

## Testing
- `npm run lint`
- `CI=true npm test -- -i` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_b_68662c7532a4833386e76ac616b67330