### PR TITLE
Simplify demo login modal

### DIFF
--- a/components/DemoLoginModal.tsx
+++ b/components/DemoLoginModal.tsx
@@ -1,247 +1,142 @@
-'use client';
+'use client'
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useState } from 'react'
+import type React from 'react'
 
 interface DemoLoginModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onLogin: () => void;
+  isOpen: boolean
+  onClose: () => void
+  onLogin: () => void
 }
 
-const DemoLoginModal = ({
-  isOpen,
-  onClose,
-  onLogin,
-}: DemoLoginModalProps) => {
-  const [emailValue, setEmailValue] = useState('');
-  const [passwordValue, setPasswordValue] = useState('');
-  const [isTypingEmail, setIsTypingEmail] = useState(false);
-  const [isTypingPassword, setIsTypingPassword] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
-  const [hasStarted, setHasStarted] = useState(false);
+const DEMO_EMAIL = 'demo@symfarmia.com'
+const DEMO_PASSWORD = 'demo123'
+const ANIMATION_DURATION = 250 // milliseconds
 
-  const emailTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const passwordTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+const DemoLoginModal = ({ isOpen, onClose, onLogin }: DemoLoginModalProps) => {
+  const [visible, setVisible] = useState(isOpen)
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const intervalRef = useRef<NodeJS.Timeout | null>(null)
 
-  const demoEmail = 'demo@symfarmia.com';
-  const demoPassword = 'demo123';
-
-  const typewriterDelay = 80; // milliseconds between characters
-
-  const startTypewriterEffect = useCallback(() => {
-    setEmailValue('');
-    setPasswordValue('');
-    setIsTypingEmail(true);
-    setIsTypingPassword(false);
-    setIsLoading(false);
-    setShowPassword(false);
-    setHasStarted(true);
-
-    // Type email first
-    let emailIndex = 0;
-    const typeEmail = () => {
-      if (emailIndex < demoEmail.length) {
-        setEmailValue(demoEmail.substring(0, emailIndex + 1));
-        emailIndex++;
-        emailTimeoutRef.current = setTimeout(typeEmail, typewriterDelay);
-      } else {
-        setIsTypingEmail(false);
-        setIsTypingPassword(true);
-        setShowPassword(true);
-        
-        // Start typing password after a brief pause
-        setTimeout(() => {
-          let passwordIndex = 0;
-          const typePassword = () => {
-            if (passwordIndex < demoPassword.length) {
-              setPasswordValue(demoPassword.substring(0, passwordIndex + 1));
-              passwordIndex++;
-              passwordTimeoutRef.current = setTimeout(typePassword, typewriterDelay);
-            } else {
-              setIsTypingPassword(false);
-              
-              // Show loading spinner and proceed with login after a brief pause
-              setTimeout(() => {
-                setIsLoading(true);
-                setTimeout(() => {
-                  onLogin();
-                }, 1500); // Loading duration
-              }, 500);
-            }
-          };
-          typePassword();
-        }, 300);
-      }
-    };
-    
-    // Start typing after modal animation
-    setTimeout(typeEmail, 500);
-  }, [onLogin]);
-
-  const cleanup = useCallback(() => {
-    if (emailTimeoutRef.current) {
-      clearTimeout(emailTimeoutRef.current);
-      emailTimeoutRef.current = null;
-    }
-    if (passwordTimeoutRef.current) {
-      clearTimeout(passwordTimeoutRef.current);
-      passwordTimeoutRef.current = null;
-    }
-    setEmailValue('');
-    setPasswordValue('');
-    setIsTypingEmail(false);
-    setIsTypingPassword(false);
-    setIsLoading(false);
-    setShowPassword(false);
-    setHasStarted(false);
-  }, []);
-
+  // Handle mount/unmount for fade transitions
   useEffect(() => {
-    if (isOpen && !hasStarted) {
-      startTypewriterEffect();
-    } else if (!isOpen) {
-      cleanup();
+    if (isOpen) {
+      setVisible(true)
+      return
     }
 
-    return cleanup;
-  }, [isOpen, hasStarted, startTypewriterEffect, cleanup]);
+    const timeout = setTimeout(() => setVisible(false), ANIMATION_DURATION)
+    return () => clearTimeout(timeout)
+  }, [isOpen])
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleBackdropClick = (e: any) => {
-    if (e.target === e.currentTarget && !isLoading) {
-      onClose();
+  // Auto type demo credentials when the modal opens
+  useEffect(() => {
+    if (!isOpen) {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+      return
     }
-  };
 
-  if (!isOpen) return null;
+    setEmail('')
+    setPassword('')
+    let emailIndex = 0
+    let passIndex = 0
+
+    intervalRef.current = setInterval(() => {
+      if (emailIndex < DEMO_EMAIL.length) {
+        setEmail(DEMO_EMAIL.slice(0, emailIndex + 1))
+        emailIndex += 1
+      } else if (passIndex < DEMO_PASSWORD.length) {
+        setPassword(DEMO_PASSWORD.slice(0, passIndex + 1))
+        passIndex += 1
+      } else if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+      }
+    }, 80)
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [isOpen])
+
+  // Close modal on Escape key
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [isOpen, onClose])
+
+  const handleBackdrop = (e: any) => {
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  if (!visible) return null
 
   return (
-    <div 
-      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
-      onClick={handleBackdropClick}
+    <div
+      onClick={handleBackdrop}
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/50 transition-opacity duration-200 ${
+        isOpen ? 'opacity-100' : 'opacity-0'
+      }`}
     >
-      <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative animate-scale-in">
-        {/* Close button */}
-        {!isLoading && (
-          <button
-            onClick={onClose}
-            className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 transition-colors"
-            aria-label="Close modal"
-          >
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        )}
+      <div
+        className={`relative w-full max-w-md transform rounded-lg bg-white p-6 shadow-lg transition-all duration-200 ${
+          isOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
+        }`}
+      >
+        <button
+          aria-label="Close"
+          onClick={onClose}
+          className="absolute right-4 top-4 text-gray-400 transition-colors hover:text-gray-600"
+        >
+          <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
 
-        {/* Header */}
-        <div className="text-center mb-6">
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">Demo Login</h2>
-          <p className="text-gray-600 text-sm">
-            Watch as we automatically fill in demo credentials
-          </p>
-        </div>
+        <h2 className="mb-4 text-center text-2xl font-bold text-gray-900">Demo Login</h2>
 
-        {/* Form */}
         <div className="space-y-4">
-          {/* Email Field */}
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+            <label htmlFor="email" className="mb-1 block text-sm font-medium text-gray-700">
               Email
             </label>
-            <div className="relative">
-              <input
-                type="email"
-                id="email"
-                value={emailValue}
-                readOnly
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                placeholder=""
-              />
-              {isTypingEmail && (
-                <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
-                  <div className="w-0.5 h-5 bg-blue-500 animate-pulse"></div>
-                </div>
-              )}
-            </div>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
           </div>
 
-          {/* Password Field */}
-          <div className={showPassword ? 'opacity-100' : 'opacity-30'}>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
+          <div>
+            <label htmlFor="password" className="mb-1 block text-sm font-medium text-gray-700">
               Password
             </label>
-            <div className="relative">
-              <input
-                type="password"
-                id="password"
-                value={passwordValue}
-                readOnly
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                placeholder=""
-              />
-              {isTypingPassword && (
-                <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
-                  <div className="w-0.5 h-5 bg-blue-500 animate-pulse"></div>
-                </div>
-              )}
-            </div>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
           </div>
 
-          {/* Login Button */}
-          <div className="pt-4">
-            <button
-              disabled={isLoading || isTypingEmail || isTypingPassword}
-              className={`w-full py-3 px-4 rounded-md font-semibold text-white transition-all duration-200 ${
-                isLoading || isTypingEmail || isTypingPassword
-                  ? 'bg-gray-400 cursor-not-allowed'
-                  : 'bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2'
-              }`}
-            >
-              {isLoading ? (
-                <div className="flex items-center justify-center">
-                  <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                  </svg>
-                  Logging in...
-                </div>
-              ) : isTypingEmail || isTypingPassword ? (
-                'Typing credentials...'
-              ) : (
-                'Login to Demo'
-              )}
-            </button>
-          </div>
-        </div>
-
-        {/* Info message */}
-        <div className="mt-4 text-center">
-          <p className="text-xs text-gray-500">
-            Demo mode provides full access with sample data
-          </p>
+          <button
+            onClick={onLogin}
+            className="w-full rounded-md bg-blue-600 py-2 font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 active:scale-95"
+          >
+            Login to Demo
+          </button>
         </div>
       </div>
-
-      <style>{`
-        .animate-scale-in {
-          animation: scaleIn 0.2s ease-out;
-        }
-        
-        @keyframes scaleIn {
-          from {
-            opacity: 0;
-            transform: scale(0.95);
-          }
-          to {
-            opacity: 1;
-            transform: scale(1);
-          }
-        }
-      `}</style>
     </div>
-  );
-};
+  )
+}
 
-export default DemoLoginModal;
+export default DemoLoginModal
+


### PR DESCRIPTION
## Summary
- rebuild demo login modal with minimal state
- use simple typewriter effect for demo credentials
- add basic Tailwind transitions

## Testing
- `npm run lint`
- `npm test` *(fails: useTranslation must be used within I18nProvider)*

------
https://chatgpt.com/codex/tasks/task_b_6866eed8c4508333956cbafd838388d7