### PR TITLE
Fix icon exports and lint issues

### DIFF
--- a/app/providers/AppModeProvider.tsx
+++ b/app/providers/AppModeProvider.tsx
@@ -38,7 +38,7 @@ export function AppModeProvider({ children }: { children: React.ReactNode }) {
       return 'live';
     };
     setAppMode(detectMode());
-  }, []);
+  }, [setAppMode]);
 
   useEffect(() => {
     if (appMode === 'demo') {

--- a/src/components/CinematicLandingPage.jsx
+++ b/src/components/CinematicLandingPage.jsx
@@ -1,16 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { motion, useScroll, useTransform } from 'framer-motion';
 import { useTranslation } from '../../app/providers/I18nProvider';
-import { 
-  HeartIcon, 
-  BrainIcon, 
-  SunIcon, 
+import {
+  HeartIcon,
+  SunIcon,
   ChartBarIcon,
   DocumentTextIcon,
-  BeakerIcon,
   ClipboardDocumentCheckIcon,
   ExclamationTriangleIcon,
-  TrendingUpIcon,
   ClockIcon,
   CurrencyDollarIcon,
   UserGroupIcon,
@@ -22,6 +19,7 @@ import {
   ArrowTrendingUpIcon,
   EyeIcon
 } from '@heroicons/react/24/outline';
+import MedicalBrainIcon from './MedicalBrainIcon';
 import LanguageToggle from '../../components/LanguageToggle';
 
 const CinematicLandingPage = () => {
@@ -30,7 +28,6 @@ const CinematicLandingPage = () => {
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
   
   // Parallax effects
-  const heroY = useTransform(scrollYProgress, [0, 1], ['0%', '50%']);
   const textY = useTransform(scrollYProgress, [0, 1], ['0%', '100%']);
   const particleY = useTransform(scrollYProgress, [0, 1], ['0%', '200%']);
   
@@ -109,7 +106,7 @@ const CinematicLandingPage = () => {
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="relative">
               <HeartIcon className="w-16 h-16 text-red-400 absolute -top-4 -left-4" />
-              <BrainIcon className="w-16 h-16 text-blue-400 absolute -top-4 -right-4" />
+              <MedicalBrainIcon className="w-16 h-16 text-blue-400 absolute -top-4 -right-4" />
               <div className="w-12 h-12 bg-teal-400 rounded-full opacity-80 animate-pulse" />
             </div>
           </div>
@@ -354,7 +351,7 @@ const CinematicLandingPage = () => {
             {
               title: t('assisted_diagnosis'),
               description: t('assisted_diagnosis_desc'),
-              icon: BrainIcon,
+              icon: MedicalBrainIcon,
               color: 'from-blue-400 to-purple-500',
               delay: 0.4
             },
@@ -444,7 +441,7 @@ const CinematicLandingPage = () => {
           viewport={{ once: true }}
         >
           <div className="inline-flex items-center bg-gradient-to-r from-teal-500/20 to-blue-500/20 backdrop-blur-sm px-6 py-3 rounded-full border border-teal-400/30">
-            <TrendingUpIcon className="w-5 h-5 text-teal-400 mr-2" />
+            <ArrowTrendingUpIcon className="w-5 h-5 text-teal-400 mr-2" />
             <span className="text-white font-medium">
               {t('journey_progress')}
             </span>
@@ -933,7 +930,7 @@ const CinematicLandingPage = () => {
             
             <div className="relative z-10">
               <div className="w-16 h-16 mb-6 bg-gradient-to-r from-teal-400 to-blue-500 p-3 rounded-xl">
-                <BrainIcon className="w-full h-full text-white" />
+                <MedicalBrainIcon className="w-full h-full text-white" />
               </div>
               
               <h3 className="text-2xl font-bold text-white mb-4">
@@ -1056,7 +1053,6 @@ const CinematicLandingPage = () => {
 
   // Pricing Section - "PLANES DE TRANSFORMACIÓN"
   const PricingSection = () => {
-    const [selectedPlan, setSelectedPlan] = useState('profesional');
     
     const plans = [
       {

--- a/src/components/MedicalCharts.jsx
+++ b/src/components/MedicalCharts.jsx
@@ -3,8 +3,8 @@ import React, { useState } from 'react';
 import { useTranslation } from '../../app/providers/I18nProvider';
 import { 
   ChartBarIcon, 
-  ChartPieIcon, 
-  TrendingUpIcon,
+  ChartPieIcon,
+  ArrowTrendingUpIcon,
   CalendarDaysIcon,
   UsersIcon,
   HeartIcon
@@ -17,7 +17,7 @@ const MedicalCharts = ({ section = 'overview' }) => {
   const chartOptions = {
     overview: [
       { id: 'diagnoses', name: t('common_diagnoses'), icon: ChartPieIcon },
-      { id: 'outcomes', name: t('treatment_outcomes'), icon: TrendingUpIcon },
+      { id: 'outcomes', name: t('treatment_outcomes'), icon: ArrowTrendingUpIcon },
       { id: 'demographics', name: t('patient_demographics'), icon: UsersIcon },
       { id: 'trends', name: t('seasonal_trends'), icon: CalendarDaysIcon }
     ],
@@ -28,12 +28,12 @@ const MedicalCharts = ({ section = 'overview' }) => {
     ],
     clinical: [
       { id: 'diagnoses', name: t('common_diagnoses'), icon: ChartPieIcon },
-      { id: 'outcomes', name: t('treatment_outcomes'), icon: TrendingUpIcon },
+      { id: 'outcomes', name: t('treatment_outcomes'), icon: ArrowTrendingUpIcon },
       { id: 'adherence', name: t('medication_adherence'), icon: ChartBarIcon }
     ],
     reports: [
       { id: 'revenue', name: t('revenue_this_month'), icon: ChartBarIcon },
-      { id: 'costs', name: t('cost_per_patient'), icon: TrendingUpIcon },
+      { id: 'costs', name: t('cost_per_patient'), icon: ArrowTrendingUpIcon },
       { id: 'efficiency', name: t('operational_efficiency'), icon: ChartPieIcon }
     ]
   };

--- a/src/components/MedicalKPICards.jsx
+++ b/src/components/MedicalKPICards.jsx
@@ -7,8 +7,8 @@ import {
   ClipboardDocumentCheckIcon,
   FaceSmileIcon,
   ClockIcon,
-  TrendingUpIcon,
-  TrendingDownIcon,
+  ArrowTrendingUpIcon,
+  ArrowTrendingDownIcon,
   CurrencyDollarIcon,
   ChartBarIcon,
   ShieldCheckIcon,
@@ -76,7 +76,7 @@ const MedicalKPICards = ({ section = 'overview' }) => {
             value: '87.3%',
             change: '+3.4%',
             changeType: 'increase',
-            icon: TrendingUpIcon,
+            icon: ArrowTrendingUpIcon,
             color: 'blue',
             description: 'Patient recovery rate'
           },
@@ -94,7 +94,7 @@ const MedicalKPICards = ({ section = 'overview' }) => {
             value: '4.2%',
             change: '-1.8%',
             changeType: 'decrease',
-            icon: TrendingDownIcon,
+            icon: ArrowTrendingDownIcon,
             color: 'red',
             description: '30-day readmission rate'
           }
@@ -209,9 +209,9 @@ const MedicalKPICards = ({ section = 'overview' }) => {
                 : 'text-red-600 dark:text-red-400'
             }`}>
               {kpi.changeType === 'increase' ? (
-                <TrendingUpIcon className="w-4 h-4 mr-1" />
+                <ArrowTrendingUpIcon className="w-4 h-4 mr-1" />
               ) : (
-                <TrendingDownIcon className="w-4 h-4 mr-1" />
+                <ArrowTrendingDownIcon className="w-4 h-4 mr-1" />
               )}
               {kpi.change}
             </div>

--- a/src/utils/medicalUtils.js
+++ b/src/utils/medicalUtils.js
@@ -398,7 +398,7 @@ export const mockMedicalAI = {
       }
     },
 
-  _fallbackResponse: (message) => {
+  _fallbackResponse: (_message) => {
     const defaultResponses = [
       "I understand you're looking for medical guidance. Could you provide more specific details about the patient's condition?",
       "Based on the information provided, I'd recommend a comprehensive evaluation. What specific aspect would you like me to focus on?",


### PR DESCRIPTION
## Summary
- replace missing heroicons exports with available ones
- switch CinematicLandingPage to use the local `MedicalBrainIcon`
- remove unused variables and imports
- include `setAppMode` in `AppModeProvider` dependency list
- silence unused argument warning in `medicalUtils`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_b_68674f2ee1748333a26a6e894ba8930b