### PR TITLE
Fix LandingPage context provider usage

### DIFF
--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -6,6 +6,7 @@ import DemoLoginModal from '../../components/DemoLoginModal';
 import PatientManagementPreview from '../components/PatientManagementPreview';
 import MedicalReportsPreview from '../components/MedicalReportsPreview';
 import { AppModeProvider } from '../../app/providers/AppModeProvider';
+import { PatientContextProvider } from '../../app/providers/PatientContextProvider';
 import { useDemoHighlight } from '../../hooks/useDemoHighlight';
 import ThemeToggle from '../../components/ThemeToggle';
 import LanguageToggle from '../../components/LanguageToggle';
@@ -172,9 +173,11 @@ const LandingPageContent = () => {
 
 const LandingPage = () => (
   <I18nProvider>
-    <AppModeProvider>
-      <LandingPageContent />
-    </AppModeProvider>
+    <PatientContextProvider>
+      <AppModeProvider>
+        <LandingPageContent />
+      </AppModeProvider>
+    </PatientContextProvider>
   </I18nProvider>
 );
 


### PR DESCRIPTION
## Summary
- wrap LandingPage with `PatientContextProvider`

## Testing
- `npm test` *(fails: useTranslation must be used within I18nProvider)*

------
https://chatgpt.com/codex/tasks/task_b_686753ca3cd883339ad8267c2a75af8e