### PR TITLE
Fix ThemeProvider usage in LandingPage

### DIFF
--- a/__tests__/HomePage.test.jsx
+++ b/__tests__/HomePage.test.jsx
@@ -2,14 +2,20 @@ import { render, screen } from '@testing-library/react'
 import HomePage from '../app/page'
 import { AppModeProvider } from '../app/providers/AppModeProvider'
 import { ThemeProvider } from '../app/providers/ThemeProvider'
+import { I18nProvider } from '../app/providers/I18nProvider'
+import { PatientContextProvider } from '../app/providers/PatientContextProvider'
 
 describe('HomePage', () => {
   it('renders the LandingPage component', () => {
     render(
       <ThemeProvider>
-        <AppModeProvider>
-          <HomePage />
-        </AppModeProvider>
+        <I18nProvider>
+          <PatientContextProvider>
+            <AppModeProvider>
+              <HomePage />
+            </AppModeProvider>
+          </PatientContextProvider>
+        </I18nProvider>
       </ThemeProvider>
     )
     expect(screen.getByText('Welcome to')).toBeInTheDocument()
@@ -19,9 +25,13 @@ describe('HomePage', () => {
   it('contains the main SYMFARMIA branding', () => {
     render(
       <ThemeProvider>
-        <AppModeProvider>
-          <HomePage />
-        </AppModeProvider>
+        <I18nProvider>
+          <PatientContextProvider>
+            <AppModeProvider>
+              <HomePage />
+            </AppModeProvider>
+          </PatientContextProvider>
+        </I18nProvider>
       </ThemeProvider>
     )
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Welcome to SYMFARMIA')
@@ -30,9 +40,13 @@ describe('HomePage', () => {
   it('displays the platform description', () => {
     render(
       <ThemeProvider>
-        <AppModeProvider>
-          <HomePage />
-        </AppModeProvider>
+        <I18nProvider>
+          <PatientContextProvider>
+            <AppModeProvider>
+              <HomePage />
+            </AppModeProvider>
+          </PatientContextProvider>
+        </I18nProvider>
       </ThemeProvider>
     )
     expect(screen.getByText('Intelligent platform for independent doctors')).toBeInTheDocument()

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -13,6 +13,7 @@ import LanguageToggle from '../../components/LanguageToggle';
 import MedicalBrainIcon from '../components/MedicalBrainIcon';
 import { useMockPatient } from '../hooks/useMockPatient';
 import { I18nProvider, useTranslation } from '../../app/providers/I18nProvider';
+import { ThemeProvider } from '../../app/providers/ThemeProvider';
 
 const LandingPageContent = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -172,13 +173,15 @@ const LandingPageContent = () => {
 };
 
 const LandingPage = () => (
-  <I18nProvider>
-    <PatientContextProvider>
-      <AppModeProvider>
-        <LandingPageContent />
-      </AppModeProvider>
-    </PatientContextProvider>
-  </I18nProvider>
+  <ThemeProvider>
+    <I18nProvider>
+      <PatientContextProvider>
+        <AppModeProvider>
+          <LandingPageContent />
+        </AppModeProvider>
+      </PatientContextProvider>
+    </I18nProvider>
+  </ThemeProvider>
 );
 
 export default LandingPage;


### PR DESCRIPTION
## Summary
- wrap LandingPage page with ThemeProvider so ThemeToggle works
- adjust HomePage tests to use required context providers

## Testing
- `npm test` *(fails: AppModeProvider and HomePage tests)*

------
https://chatgpt.com/codex/tasks/task_b_68675d4231108333bf128657c15dd714