### PR TITLE
Fix tests to use I18nProvider

### DIFF
--- a/__tests__/HomePage.test.jsx
+++ b/__tests__/HomePage.test.jsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import HomePage from '../app/page'
 import { AppModeProvider } from '../app/providers/AppModeProvider'
 import { ThemeProvider } from '../app/providers/ThemeProvider'
-import { I18nProvider } from '../app/providers/I18nProvider'
+import { I18nProvider } from 'app/providers/I18nProvider'
 import { PatientContextProvider } from '../app/providers/PatientContextProvider'
 
 describe('HomePage', () => {

--- a/__tests__/LandingPage.test.jsx
+++ b/__tests__/LandingPage.test.jsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import LandingPage from '../src/pages/LandingPage'
 import { AppModeProvider } from '../app/providers/AppModeProvider'
 import { ThemeProvider } from '../app/providers/ThemeProvider'
+import { I18nProvider } from 'app/providers/I18nProvider'
 
 // Mock window.alert
 window.alert = jest.fn()
@@ -14,9 +15,11 @@ describe('LandingPage', () => {
   it('renders the main heading', () => {
     render(
       <ThemeProvider>
-        <AppModeProvider>
-          <LandingPage />
-        </AppModeProvider>
+        <I18nProvider>
+          <AppModeProvider>
+            <LandingPage />
+          </AppModeProvider>
+        </I18nProvider>
       </ThemeProvider>
     )
     expect(screen.getByText('Welcome to')).toBeInTheDocument()
@@ -26,9 +29,11 @@ describe('LandingPage', () => {
   it('renders the subtitle', () => {
     render(
       <ThemeProvider>
-        <AppModeProvider>
-          <LandingPage />
-        </AppModeProvider>
+        <I18nProvider>
+          <AppModeProvider>
+            <LandingPage />
+          </AppModeProvider>
+        </I18nProvider>
       </ThemeProvider>
     )
     expect(screen.getByText('Intelligent platform for independent doctors')).toBeInTheDocument()
@@ -37,9 +42,11 @@ describe('LandingPage', () => {
   it('renders Login and Register buttons', () => {
     render(
       <ThemeProvider>
-        <AppModeProvider>
-          <LandingPage />
-        </AppModeProvider>
+        <I18nProvider>
+          <AppModeProvider>
+            <LandingPage />
+          </AppModeProvider>
+        </I18nProvider>
       </ThemeProvider>
     )
     expect(screen.getByRole('link', { name: /login/i })).toBeInTheDocument()
@@ -49,9 +56,11 @@ describe('LandingPage', () => {
   it('renders Try Demo Mode button', () => {
     render(
       <ThemeProvider>
-        <AppModeProvider>
-          <LandingPage />
-        </AppModeProvider>
+        <I18nProvider>
+          <AppModeProvider>
+            <LandingPage />
+          </AppModeProvider>
+        </I18nProvider>
       </ThemeProvider>
     )
     expect(screen.getByRole('button', { name: /try demo mode/i })).toBeInTheDocument()
@@ -60,9 +69,11 @@ describe('LandingPage', () => {
   it('opens the demo modal when Try Demo Mode is clicked', () => {
     render(
       <ThemeProvider>
-        <AppModeProvider>
-          <LandingPage />
-        </AppModeProvider>
+        <I18nProvider>
+          <AppModeProvider>
+            <LandingPage />
+          </AppModeProvider>
+        </I18nProvider>
       </ThemeProvider>
     )
     const demoButton = screen.getByRole('button', { name: /try demo mode/i })
@@ -73,9 +84,11 @@ describe('LandingPage', () => {
   it('renders feature cards', () => {
     render(
       <ThemeProvider>
-        <AppModeProvider>
-          <LandingPage />
-        </AppModeProvider>
+        <I18nProvider>
+          <AppModeProvider>
+            <LandingPage />
+          </AppModeProvider>
+        </I18nProvider>
       </ThemeProvider>
     )
     expect(screen.getByText('Patient Management')).toBeInTheDocument()
@@ -86,9 +99,11 @@ describe('LandingPage', () => {
   it('has correct Login link href', () => {
     render(
       <ThemeProvider>
-        <AppModeProvider>
-          <LandingPage />
-        </AppModeProvider>
+        <I18nProvider>
+          <AppModeProvider>
+            <LandingPage />
+          </AppModeProvider>
+        </I18nProvider>
       </ThemeProvider>
     )
     const loginLink = screen.getByRole('link', { name: /login/i })
@@ -98,9 +113,11 @@ describe('LandingPage', () => {
   it('has correct Register link href', () => {
     render(
       <ThemeProvider>
-        <AppModeProvider>
-          <LandingPage />
-        </AppModeProvider>
+        <I18nProvider>
+          <AppModeProvider>
+            <LandingPage />
+          </AppModeProvider>
+        </I18nProvider>
       </ThemeProvider>
     )
     const registerLink = screen.getByRole('link', { name: /register/i })
@@ -110,9 +127,11 @@ describe('LandingPage', () => {
   it('renders footer copyright', () => {
     render(
       <ThemeProvider>
-        <AppModeProvider>
-          <LandingPage />
-        </AppModeProvider>
+        <I18nProvider>
+          <AppModeProvider>
+            <LandingPage />
+          </AppModeProvider>
+        </I18nProvider>
       </ThemeProvider>
     )
     expect(screen.getByText(/© 2024 SYMFARMIA/)).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- fix imports for `I18nProvider` to use root path
- wrap LandingPage tests with `I18nProvider`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686762c9fa6883339d8206b4e801a80c