### PR TITLE
Add base repository interfaces

### DIFF
--- a/app/domain/repositories/BaseRepository.ts
+++ b/app/domain/repositories/BaseRepository.ts
@@ -1,0 +1,12 @@
+export interface BaseRepository<T, CreateDTO = Partial<T>, UpdateDTO = Partial<T>> {
+  /** Retrieve all entities */
+  findAll(): Promise<T[]>;
+  /** Find a single entity by id */
+  findById(id: number): Promise<T | null>;
+  /** Create a new entity */
+  create(data: CreateDTO): Promise<T>;
+  /** Update an existing entity */
+  update(id: number, data: UpdateDTO): Promise<T>;
+  /** Delete an entity by id */
+  delete(id: number): Promise<void>;
+}

--- a/app/domain/repositories/interfaces/IMedicalReportRepository.ts
+++ b/app/domain/repositories/interfaces/IMedicalReportRepository.ts
@@ -1,0 +1,8 @@
+import { MedicalReport, CreateMedicalReportData, UpdateMedicalReportData } from '@/types';
+import { BaseRepository } from '../BaseRepository';
+
+export interface IMedicalReportRepository extends BaseRepository<
+  MedicalReport,
+  CreateMedicalReportData,
+  UpdateMedicalReportData
+> {}

--- a/app/domain/repositories/interfaces/IPatientRepository.ts
+++ b/app/domain/repositories/interfaces/IPatientRepository.ts
@@ -1,0 +1,8 @@
+import { Patient, CreatePatientData, UpdatePatientData } from '@/types';
+import { BaseRepository } from '../BaseRepository';
+
+export interface IPatientRepository extends BaseRepository<
+  Patient,
+  CreatePatientData,
+  UpdatePatientData
+> {}

--- a/app/domain/repositories/interfaces/IStudyTypeRepository.ts
+++ b/app/domain/repositories/interfaces/IStudyTypeRepository.ts
@@ -1,0 +1,8 @@
+import { StudyType, CreateStudyTypeData, UpdateStudyTypeData } from '@/types';
+import { BaseRepository } from '../BaseRepository';
+
+export interface IStudyTypeRepository extends BaseRepository<
+  StudyType,
+  CreateStudyTypeData,
+  UpdateStudyTypeData
+> {}


### PR DESCRIPTION
## Summary
- add `BaseRepository` with CRUD method signatures
- define repository interfaces for patient, medical report, and study type entities

## Testing
- `npm test` *(fails: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_686779a69a748333a112a273a7032744