### PR TITLE
Refactor providers with strict types

### DIFF
--- a/app/providers/APIProvider.ts
+++ b/app/providers/APIProvider.ts
@@ -1,61 +1,73 @@
+import type {
+  Category,
+  EmailData,
+  MedicalReport,
+  MergePdfData,
+  MergePdfResult,
+  Patient,
+  Study,
+  StudyType,
+  APIResponse
+} from '@/types/providers';
+
 export abstract class APIProvider {
-  async fetchPatients(): Promise<unknown> {
+  async fetchPatients(): Promise<Patient[]> {
     throw new Error('fetchPatients must be implemented');
   }
 
-  async savePatient(_patient: unknown): Promise<unknown> {
+  async savePatient(_patient: Partial<Patient>): Promise<APIResponse<boolean>> {
     throw new Error('savePatient must be implemented');
   }
 
-  async removePatient(_patientId: number | string): Promise<unknown> {
+  async removePatient(_patientId: number): Promise<APIResponse<boolean>> {
     throw new Error('removePatient must be implemented');
   }
 
-  async fetchMedicalReports(): Promise<unknown> {
+  async fetchMedicalReports(): Promise<MedicalReport[]> {
     throw new Error('fetchMedicalReports must be implemented');
   }
 
-  async fetchMedicalReport(_reportId: number | string): Promise<unknown> {
+  async fetchMedicalReport(_reportId: number): Promise<MedicalReport | null> {
     throw new Error('fetchMedicalReport must be implemented');
   }
 
-  async saveMedicalReport(_report: unknown): Promise<unknown> {
+  async saveMedicalReport(_report: Partial<MedicalReport>): Promise<APIResponse<boolean>> {
     throw new Error('saveMedicalReport must be implemented');
   }
 
-  async removeMedicalReport(_reportId: number | string): Promise<unknown> {
+  async removeMedicalReport(_reportId: number): Promise<APIResponse<boolean>> {
     throw new Error('removeMedicalReport must be implemented');
   }
 
-  async fetchCategories(): Promise<unknown> {
+  async fetchCategories(): Promise<Category[]> {
     throw new Error('fetchCategories must be implemented');
   }
 
-  async saveCategory(_category: unknown): Promise<unknown> {
+  async saveCategory(_category: Partial<Category>): Promise<APIResponse<boolean>> {
     throw new Error('saveCategory must be implemented');
   }
 
-  async fetchStudyTypes(): Promise<unknown> {
+  async fetchStudyTypes(): Promise<StudyType[]> {
     throw new Error('fetchStudyTypes must be implemented');
   }
 
-  async saveStudyType(_studyType: unknown): Promise<unknown> {
+  async saveStudyType(_studyType: Partial<StudyType>): Promise<APIResponse<boolean>> {
     throw new Error('saveStudyType must be implemented');
   }
 
-  async saveStudy(_study: unknown): Promise<unknown> {
+  async saveStudy(_study: Partial<Study>): Promise<APIResponse<boolean>> {
     throw new Error('saveStudy must be implemented');
   }
 
-  async removeStudy(_studyId: number | string): Promise<unknown> {
+  async removeStudy(_studyId: number): Promise<APIResponse<boolean>> {
     throw new Error('removeStudy must be implemented');
   }
 
-  async sendTokenByEmail(_emailData: unknown): Promise<unknown> {
+  async sendTokenByEmail(_emailData: EmailData): Promise<APIResponse<boolean>> {
     throw new Error('sendTokenByEmail must be implemented');
   }
 
-  async mergePdfs(_pdfData: unknown): Promise<unknown> {
+  async mergePdfs(_pdfData: MergePdfData): Promise<MergePdfResult> {
     throw new Error('mergePdfs must be implemented');
   }
 }

--- a/app/providers/DemoAPIProvider.ts
+++ b/app/providers/DemoAPIProvider.ts
@@ -1,7 +1,19 @@
 import { APIProvider } from './APIProvider';
+import type {
+  APIResponse,
+  Category,
+  DemoData,
+  EmailData,
+  MedicalReport,
+  Patient,
+  Study,
+  StudyType,
+  MergePdfData,
+  MergePdfResult
+} from '@/types/providers';
 
 export class DemoAPIProvider extends APIProvider {
-  private demoData: any;
+  private demoData: DemoData;
 
   constructor() {
     super();
@@ -17,14 +29,14 @@ export class DemoAPIProvider extends APIProvider {
       const live = new LiveAPIProvider();
       const patients = await live.fetchPatients();
       if (Array.isArray(patients)) {
-        this.demoData.patients = patients as unknown[];
+        this.demoData.patients = patients;
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.warn('[DEMO MODE] Live sync failed:', error);
     }
   }
 
-  initializeDemoData(): any {
+  initializeDemoData(): DemoData {
     return {
       patients: [
         {
@@ -128,195 +140,203 @@ export class DemoAPIProvider extends APIProvider {
     };
   }
 
-  async fetchPatients() {
-    return new Promise((resolve) => {
+  async fetchPatients(): Promise<Patient[]> {
+    return new Promise<Patient[]>((resolve) => {
       setTimeout(() => {
         resolve(this.demoData.patients);
       }, 500);
     });
   }
 
-  async savePatient(patient: any) {
-    return new Promise((resolve) => {
+  async savePatient(patient: Partial<Patient>): Promise<APIResponse<boolean>> {
+    return new Promise<APIResponse<boolean>>((resolve) => {
       setTimeout(() => {
         if (patient.id) {
-          const index = this.demoData.patients.findIndex((p: any) => p.id === patient.id);
+          const index = this.demoData.patients.findIndex((p) => p.id === patient.id);
           if (index !== -1) {
-            this.demoData.patients[index] = { ...patient, updatedAt: new Date().toISOString() };
+            this.demoData.patients[index] = {
+              ...this.demoData.patients[index],
+              ...patient,
+              updatedAt: new Date().toISOString()
+            } as Patient;
           }
         } else {
-          const newPatient = {
-            ...patient,
-            id: Math.max(...this.demoData.patients.map((p: any) => p.id)) + 1,
+          const newPatient: Patient = {
+            ...(patient as Patient),
+            id: Math.max(...this.demoData.patients.map((p) => p.id)) + 1,
             createdAt: new Date().toISOString(),
             updatedAt: new Date().toISOString()
           };
           this.demoData.patients.push(newPatient);
         }
-        resolve({ success: true });
+        resolve({ success: true, data: true });
       }, 300);
     });
   }
 
-  async removePatient(patientId: any) {
-    return new Promise((resolve) => {
+  async removePatient(patientId: number): Promise<APIResponse<boolean>> {
+    return new Promise<APIResponse<boolean>>((resolve) => {
       setTimeout(() => {
-        this.demoData.patients = this.demoData.patients.filter((p: any) => p.id !== patientId);
-        this.demoData.medicalReports = this.demoData.medicalReports.filter((r: any) => r.patientId !== patientId);
-        resolve({ success: true });
+        this.demoData.patients = this.demoData.patients.filter((p) => p.id !== patientId);
+        this.demoData.medicalReports = this.demoData.medicalReports.filter((r) => r.patientId !== patientId);
+        resolve({ success: true, data: true });
       }, 300);
     });
   }
 
-  async fetchMedicalReports() {
-    return new Promise((resolve) => {
+  async fetchMedicalReports(): Promise<MedicalReport[]> {
+    return new Promise<MedicalReport[]>((resolve) => {
       setTimeout(() => {
         resolve(this.demoData.medicalReports);
       }, 500);
     });
   }
 
-  async fetchMedicalReport(reportId: any) {
-    return new Promise((resolve) => {
+  async fetchMedicalReport(reportId: number): Promise<MedicalReport | null> {
+    return new Promise<MedicalReport | null>((resolve) => {
       setTimeout(() => {
-        const report = this.demoData.medicalReports.find((r: any) => r.id === parseInt(reportId));
+        const report = this.demoData.medicalReports.find((r) => r.id === reportId);
         resolve(report || null);
       }, 300);
     });
   }
 
-  async saveMedicalReport(report: any) {
-    return new Promise((resolve) => {
+  async saveMedicalReport(report: Partial<MedicalReport>): Promise<APIResponse<boolean>> {
+    return new Promise<APIResponse<boolean>>((resolve) => {
       setTimeout(() => {
         if (report.id) {
-          const index = this.demoData.medicalReports.findIndex((r: any) => r.id === report.id);
+          const index = this.demoData.medicalReports.findIndex((r) => r.id === report.id);
           if (index !== -1) {
-            this.demoData.medicalReports[index] = { ...report, updatedAt: new Date().toISOString() };
+            this.demoData.medicalReports[index] = {
+              ...this.demoData.medicalReports[index],
+              ...report,
+              updatedAt: new Date().toISOString()
+            } as MedicalReport;
           }
         } else {
-          const newReport = {
-            ...report,
-            id: Math.max(...this.demoData.medicalReports.map((r: any) => r.id)) + 1,
+          const newReport: MedicalReport = {
+            ...(report as MedicalReport),
+            id: Math.max(...this.demoData.medicalReports.map((r) => r.id)) + 1,
             createdAt: new Date().toISOString(),
             updatedAt: new Date().toISOString()
           };
           this.demoData.medicalReports.push(newReport);
         }
-        resolve({ success: true });
+        resolve({ success: true, data: true });
       }, 300);
     });
   }
 
-  async removeMedicalReport(reportId: any) {
-    return new Promise((resolve) => {
+  async removeMedicalReport(reportId: number): Promise<APIResponse<boolean>> {
+    return new Promise<APIResponse<boolean>>((resolve) => {
       setTimeout(() => {
-        this.demoData.medicalReports = this.demoData.medicalReports.filter((r: any) => r.id !== reportId);
-        this.demoData.studies = this.demoData.studies.filter((s: any) => s.medicalReportId !== reportId);
-        resolve({ success: true });
+        this.demoData.medicalReports = this.demoData.medicalReports.filter((r) => r.id !== reportId);
+        this.demoData.studies = this.demoData.studies.filter((s) => s.medicalReportId !== reportId);
+        resolve({ success: true, data: true });
       }, 300);
     });
   }
 
-  async fetchCategories() {
-    return new Promise((resolve) => {
+  async fetchCategories(): Promise<Category[]> {
+    return new Promise<Category[]>((resolve) => {
       setTimeout(() => {
         resolve(this.demoData.categories);
       }, 300);
     });
   }
 
-  async saveCategory(category: any) {
-    return new Promise((resolve) => {
+  async saveCategory(category: Partial<Category>): Promise<APIResponse<boolean>> {
+    return new Promise<APIResponse<boolean>>((resolve) => {
       setTimeout(() => {
         if (category.id) {
-          const index = this.demoData.categories.findIndex((c: any) => c.id === category.id);
+          const index = this.demoData.categories.findIndex((c) => c.id === category.id);
           if (index !== -1) {
-            this.demoData.categories[index] = category;
+            this.demoData.categories[index] = { ...this.demoData.categories[index], ...category } as Category;
           }
         } else {
-          const newCategory = {
-            ...category,
-            id: Math.max(...this.demoData.categories.map((c: any) => c.id)) + 1
+          const newCategory: Category = {
+            ...(category as Category),
+            id: Math.max(...this.demoData.categories.map((c) => c.id)) + 1
           };
           this.demoData.categories.push(newCategory);
         }
-        resolve({ success: true });
+        resolve({ success: true, data: true });
       }, 300);
     });
   }
 
-  async fetchStudyTypes() {
-    return new Promise((resolve) => {
+  async fetchStudyTypes(): Promise<StudyType[]> {
+    return new Promise<StudyType[]>((resolve) => {
       setTimeout(() => {
         resolve(this.demoData.studyTypes);
       }, 300);
     });
   }
 
-  async saveStudyType(studyType: any) {
-    return new Promise((resolve) => {
+  async saveStudyType(studyType: Partial<StudyType>): Promise<APIResponse<boolean>> {
+    return new Promise<APIResponse<boolean>>((resolve) => {
       setTimeout(() => {
         if (studyType.id) {
-        const index = this.demoData.studyTypes.findIndex((st: any) => st.id === studyType.id);
+        const index = this.demoData.studyTypes.findIndex((st) => st.id === studyType.id);
           if (index !== -1) {
-            this.demoData.studyTypes[index] = studyType;
+            this.demoData.studyTypes[index] = { ...this.demoData.studyTypes[index], ...studyType } as StudyType;
           }
         } else {
-          const newStudyType = {
-            ...studyType,
-            id: Math.max(...this.demoData.studyTypes.map((st: any) => st.id)) + 1
+          const newStudyType: StudyType = {
+            ...(studyType as StudyType),
+            id: Math.max(...this.demoData.studyTypes.map((st) => st.id)) + 1
           };
           this.demoData.studyTypes.push(newStudyType);
         }
-        resolve({ success: true });
+        resolve({ success: true, data: true });
       }, 300);
     });
   }
 
-  async saveStudy(study: any) {
-    return new Promise((resolve) => {
+  async saveStudy(study: Partial<Study>): Promise<APIResponse<boolean>> {
+    return new Promise<APIResponse<boolean>>((resolve) => {
       setTimeout(() => {
         if (study.id) {
-          const index = this.demoData.studies.findIndex((s: any) => s.id === study.id);
+          const index = this.demoData.studies.findIndex((s) => s.id === study.id);
           if (index !== -1) {
-            this.demoData.studies[index] = study;
+            this.demoData.studies[index] = { ...this.demoData.studies[index], ...study } as Study;
           }
         } else {
-          const newStudy = {
-            ...study,
-            id: Math.max(...this.demoData.studies.map((s: any) => s.id)) + 1
+          const newStudy: Study = {
+            ...(study as Study),
+            id: Math.max(...this.demoData.studies.map((s) => s.id)) + 1
           };
           this.demoData.studies.push(newStudy);
         }
-        resolve({ success: true });
+        resolve({ success: true, data: true });
       }, 300);
     });
   }
 
-  async removeStudy(studyId: any) {
-    return new Promise((resolve) => {
+  async removeStudy(studyId: number): Promise<APIResponse<boolean>> {
+    return new Promise<APIResponse<boolean>>((resolve) => {
       setTimeout(() => {
-        this.demoData.studies = this.demoData.studies.filter((s: any) => s.id !== studyId);
-        resolve({ success: true });
+        this.demoData.studies = this.demoData.studies.filter((s) => s.id !== studyId);
+        resolve({ success: true, data: true });
       }, 300);
     });
   }
 
-  async sendTokenByEmail(emailData: any) {
-    return new Promise((resolve) => {
+  async sendTokenByEmail(emailData: EmailData): Promise<APIResponse<boolean>> {
+    return new Promise<APIResponse<boolean>>((resolve) => {
       setTimeout(() => {
         console.log('[DEMO MODE] Email would be sent:', emailData);
-        resolve({ success: true, message: 'Demo: Email sent successfully' });
+        resolve({ success: true, data: true, message: 'Demo: Email sent successfully' });
       }, 1000);
     });
   }
 
-  async mergePdfs(pdfData: any) {
-    return new Promise((resolve) => {
+  async mergePdfs(pdfData: MergePdfData): Promise<MergePdfResult> {
+    return new Promise<MergePdfResult>((resolve) => {
       setTimeout(() => {
         console.log('[DEMO MODE] PDFs would be merged:', pdfData);
-        resolve({ 
-          success: true, 
+        resolve({
+          success: true,
           url: 'demo-merged-document.pdf',
           message: 'Demo: PDFs merged successfully'
         });

--- a/app/providers/LiveAPIProvider.ts
+++ b/app/providers/LiveAPIProvider.ts
@@ -1,20 +1,33 @@
 import { APIProvider } from './APIProvider';
+import type {
+  APIResponse,
+  Category,
+  EmailData,
+  MedicalReport,
+  MergePdfData,
+  MergePdfResult,
+  Patient,
+  Study,
+  StudyType
+} from '@/types/providers';
 
 export class LiveAPIProvider extends APIProvider {
-  async fetchPatients() {
+  async fetchPatients(): Promise<Patient[]> {
     try {
       const response = await fetch('/api/patients');
       if (response.ok) {
-        return await response.json();
-      } else {
-        throw new Error('Error fetching patients');
+        return (await response.json()) as Patient[];
       }
-    } catch (error: any) {
-      throw new Error('Error fetching patients: ' + error.message);
+      throw new Error('Error fetching patients');
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error('Error fetching patients: ' + error.message);
+      }
+      throw error;
     }
   }
 
-  async savePatient(patient: any) {
+  async savePatient(patient: Partial<Patient>): Promise<APIResponse<boolean>> {
     try {
       const response = await fetch('/api/patients', {
         method: 'POST',
@@ -25,58 +38,60 @@ export class LiveAPIProvider extends APIProvider {
       });
 
       if (response.ok) {
-        return { success: true };
-      } else {
-        return { success: false };
+        return { success: true, data: true };
       }
-    } catch (error: any) {
+      return { success: false, data: false };
+    } catch (error: unknown) {
       throw error;
     }
   }
 
-  async removePatient(patientId: any) {
+  async removePatient(patientId: number): Promise<APIResponse<boolean>> {
     try {
       const response = await fetch(`/api/patients/${patientId}`, {
         method: 'DELETE',
       });
 
       if (response.ok) {
-        return { success: true };
-      } else {
-        return { success: false };
+        return { success: true, data: true };
       }
-    } catch (error: any) {
+      return { success: false, data: false };
+    } catch (error: unknown) {
       throw error;
     }
   }
 
-  async fetchMedicalReports() {
+  async fetchMedicalReports(): Promise<MedicalReport[]> {
     try {
       const response = await fetch('/api/medicalReports');
       if (response.ok) {
-        return await response.json();
-      } else {
-        throw new Error('Error fetching medical reports');
+        return (await response.json()) as MedicalReport[];
       }
-    } catch (error: any) {
-      throw new Error('Error fetching medical reports: ' + error.message);
+      throw new Error('Error fetching medical reports');
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error('Error fetching medical reports: ' + error.message);
+      }
+      throw error;
     }
   }
 
-  async fetchMedicalReport(reportId: any) {
+  async fetchMedicalReport(reportId: number): Promise<MedicalReport> {
     try {
       const response = await fetch(`/api/medicalReports/${reportId}`);
       if (response.ok) {
-        return await response.json();
-      } else {
-        throw new Error('Error fetching medical report');
+        return (await response.json()) as MedicalReport;
       }
-    } catch (error: any) {
-      throw new Error('Error fetching medical report: ' + error.message);
+      throw new Error('Error fetching medical report');
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error('Error fetching medical report: ' + error.message);
+      }
+      throw error;
     }
   }
 
-  async saveMedicalReport(report: any) {
+  async saveMedicalReport(report: Partial<MedicalReport>): Promise<APIResponse<boolean>> {
     try {
       const response = await fetch('/api/medicalReports', {
         method: 'POST',
@@ -87,45 +102,45 @@ export class LiveAPIProvider extends APIProvider {
       });
 
       if (response.ok) {
-        return { success: true };
-      } else {
-        return { success: false };
+        return { success: true, data: true };
       }
-    } catch (error: any) {
+      return { success: false, data: false };
+    } catch (error: unknown) {
       throw error;
     }
   }
 
-  async removeMedicalReport(reportId: any) {
+  async removeMedicalReport(reportId: number): Promise<APIResponse<boolean>> {
     try {
       const response = await fetch(`/api/medicalReports/${reportId}`, {
         method: 'DELETE',
       });
 
       if (response.ok) {
-        return { success: true };
-      } else {
-        return { success: false };
+        return { success: true, data: true };
       }
-    } catch (error: any) {
+      return { success: false, data: false };
+    } catch (error: unknown) {
       throw error;
     }
   }
 
-  async fetchCategories() {
+  async fetchCategories(): Promise<Category[]> {
     try {
       const response = await fetch('/api/categories');
       if (response.ok) {
-        return await response.json();
-      } else {
-        throw new Error('Error fetching categories');
+        return (await response.json()) as Category[];
       }
-    } catch (error: any) {
-      throw new Error('Error fetching categories: ' + error.message);
+      throw new Error('Error fetching categories');
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error('Error fetching categories: ' + error.message);
+      }
+      throw error;
     }
   }
 
-  async saveCategory(category: any) {
+  async saveCategory(category: Partial<Category>): Promise<APIResponse<boolean>> {
     try {
       const response = await fetch('/api/categories', {
         method: 'POST',
@@ -136,29 +151,30 @@ export class LiveAPIProvider extends APIProvider {
       });
 
       if (response.ok) {
-        return { success: true };
-      } else {
-        return { success: false };
+        return { success: true, data: true };
       }
-    } catch (error: any) {
+      return { success: false, data: false };
+    } catch (error: unknown) {
       throw error;
     }
   }
 
-  async fetchStudyTypes() {
+  async fetchStudyTypes(): Promise<StudyType[]> {
     try {
       const response = await fetch('/api/study-types');
       if (response.ok) {
-        return await response.json();
-      } else {
-        throw new Error('Error fetching study types');
+        return (await response.json()) as StudyType[];
       }
-    } catch (error: any) {
-      throw new Error('Error fetching study types: ' + error.message);
+      throw new Error('Error fetching study types');
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error('Error fetching study types: ' + error.message);
+      }
+      throw error;
     }
   }
 
-  async saveStudyType(studyType: any) {
+  async saveStudyType(studyType: Partial<StudyType>): Promise<APIResponse<boolean>> {
     try {
       const response = await fetch('/api/study-types', {
         method: 'POST',
@@ -169,16 +185,15 @@ export class LiveAPIProvider extends APIProvider {
       });
 
       if (response.ok) {
-        return { success: true };
-      } else {
-        return { success: false };
+        return { success: true, data: true };
       }
-    } catch (error: any) {
+      return { success: false, data: false };
+    } catch (error: unknown) {
       throw error;
     }
   }
 
-  async saveStudy(study: any) {
+  async saveStudy(study: Partial<Study>): Promise<APIResponse<boolean>> {
     try {
       const response = await fetch('/api/studies', {
         method: 'POST',
@@ -189,32 +204,30 @@ export class LiveAPIProvider extends APIProvider {
       });
 
       if (response.ok) {
-        return { success: true };
-      } else {
-        return { success: false };
+        return { success: true, data: true };
       }
-    } catch (error: any) {
+      return { success: false, data: false };
+    } catch (error: unknown) {
       throw error;
     }
   }
 
-  async removeStudy(studyId: any) {
+  async removeStudy(studyId: number): Promise<APIResponse<boolean>> {
     try {
       const response = await fetch(`/api/studies/${studyId}`, {
         method: 'DELETE',
       });
 
       if (response.ok) {
-        return { success: true };
-      } else {
-        return { success: false };
+        return { success: true, data: true };
       }
-    } catch (error: any) {
+      return { success: false, data: false };
+    } catch (error: unknown) {
       throw error;
     }
   }
 
-  async sendTokenByEmail(emailData: any) {
+  async sendTokenByEmail(emailData: EmailData): Promise<APIResponse<boolean>> {
     try {
       const response = await fetch('/api/mailerHelper', {
         method: 'POST',
@@ -225,16 +238,15 @@ export class LiveAPIProvider extends APIProvider {
       });
 
       if (response.ok) {
-        return { success: true };
-      } else {
-        return { success: false };
+        return { success: true, data: true };
       }
-    } catch (error: any) {
+      return { success: false, data: false };
+    } catch (error: unknown) {
       throw error;
     }
   }
 
-  async mergePdfs(pdfData: any) {
+  async mergePdfs(pdfData: MergePdfData): Promise<MergePdfResult> {
     try {
       const response = await fetch('/api/mergePdfs', {
         method: 'POST',
@@ -245,11 +257,10 @@ export class LiveAPIProvider extends APIProvider {
       });
 
       if (response.ok) {
-        return await response.json();
-      } else {
-        return { success: false };
+        return (await response.json()) as MergePdfResult;
       }
-    } catch (error: any) {
+      return { success: false, url: '', message: 'Error merging PDFs' };
+    } catch (error: unknown) {
       throw error;
     }
   }

--- a/types/providers.ts
+++ b/types/providers.ts
@@ -1,0 +1,84 @@
+export interface Patient {
+  id: number;
+  name: string;
+  email: string;
+  phone: string;
+  dateOfBirth: string;
+  address?: string;
+  medicalHistory?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MedicalReport {
+  id: number;
+  patientId: number;
+  diagnosis: string;
+  date: string;
+  status: string;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Study {
+  id: number;
+  medicalReportId: number;
+  studyTypeId: number;
+  result: string;
+  notes: string;
+  date: string;
+}
+
+export interface Category {
+  id: number;
+  name: string;
+  description?: string;
+}
+
+export interface StudyType {
+  id: number;
+  categoryId: number;
+  name: string;
+  description: string;
+}
+
+export interface EmailData {
+  to: string;
+  subject: string;
+  nombreDeUsuario: string;
+  fecha: string;
+  url: string;
+}
+
+export interface MergePdfData {
+  pdfUrls: string[];
+}
+
+export interface MergePdfResult {
+  success: boolean;
+  url: string;
+  message?: string;
+}
+
+export interface APIResponse<T> {
+  data: T;
+  success: boolean;
+  message?: string;
+}
+
+export type CRUDOperation<T> = {
+  create: (data: Omit<T, 'id'>) => Promise<APIResponse<T>>;
+  read: (id: number) => Promise<APIResponse<T>>;
+  update: (id: number, data: Partial<T>) => Promise<APIResponse<T>>;
+  delete: (id: number) => Promise<APIResponse<boolean>>;
+  list: () => Promise<APIResponse<T[]>>;
+};
+
+export interface DemoData {
+  patients: Patient[];
+  medicalReports: MedicalReport[];
+  categories: Category[];
+  studyTypes: StudyType[];
+  studies: Study[];
+}


### PR DESCRIPTION
## Summary
- add detailed provider entity types
- refactor demo and live providers to remove `any` usage
- type the abstract APIProvider

## Testing
- `npm run type-check`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_6867779a174483338fddaeb727d176a4