### PR TITLE
Add middleware for request validation and error handling

### DIFF
--- a/app/middleware/errorHandler.ts
+++ b/app/middleware/errorHandler.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ValidationError } from './validation'
+
+export type RouteHandler = (req: NextRequest, context?: any) => Promise<NextResponse>
+
+export function withErrorHandling(handler: RouteHandler): RouteHandler {
+  return async (req, context) => {
+    try {
+      return await handler(req, context)
+    } catch (error: any) {
+      console.error(error)
+      if (error instanceof ValidationError) {
+        return NextResponse.json({ error: error.message, details: error.errors }, { status: error.status })
+      }
+      const message = error?.message || 'Internal server error'
+      return NextResponse.json({ error: message }, { status: 500 })
+    }
+  }
+}

--- a/app/middleware/validation.ts
+++ b/app/middleware/validation.ts
@@ -1,0 +1,23 @@
+import { NextRequest } from 'next/server'
+import { ZodSchema } from 'zod'
+
+export class ValidationError extends Error {
+  status: number
+  errors?: Record<string, string[]>
+  constructor(message: string, errors?: Record<string, string[]>) {
+    super(message)
+    this.name = 'ValidationError'
+    this.status = 400
+    this.errors = errors
+  }
+}
+
+export async function validate<T>(req: NextRequest, schema: ZodSchema<T>): Promise<T> {
+  const body = await req.json()
+  const result = schema.safeParse(body)
+  if (!result.success) {
+    const errors = result.error.flatten().fieldErrors as Record<string, string[]>
+    throw new ValidationError('Invalid request payload', errors)
+  }
+  return result.data
+}

--- a/legacy_core/app/api/patients/[[...patient]]/route.js
+++ b/legacy_core/app/api/patients/[[...patient]]/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import {
   getAllPatients,
   createPatient,
@@ -6,40 +7,37 @@ import {
   getPatientById,
   deletePatient
 } from '../../../../prisma/patientsClient';
+import {
+  validate,
+  ValidationError
+} from '../../../../../../app/middleware/validation';
+import { withErrorHandling } from '../../../../../../app/middleware/errorHandler';
 
-export async function GET(req) {
-  try {
-    const patients = await getAllPatients();
-    return NextResponse.json(patients, { status: 200 });
-  } catch (error) {
-    console.error(error);
-    return NextResponse.json({ error: 'Error fetching patients' }, { status: 500 });
+const patientSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  email: z.string().email(),
+  phone: z.string()
+});
+
+export const GET = withErrorHandling(async (_req) => {
+  const patients = await getAllPatients();
+  return NextResponse.json(patients, { status: 200 });
+});
+
+export const POST = withErrorHandling(async (req) => {
+  const { id, name, email, phone } = await validate(req, patientSchema);
+
+  const existingPatient = await getPatientById(id);
+
+  if (existingPatient) {
+    const updatedPatient = await updatePatient(id, { name, email, phone });
+    return NextResponse.json(updatedPatient, { status: 200 });
+  } else {
+    const newPatient = await createPatient({ id, name, email, phone });
+    return NextResponse.json(newPatient, { status: 201 });
   }
-}
-
-export async function POST(req) {
-  try {
-    const body = await req.json();
-    const { id, name, email, phone } = body;
-
-    if (!id || !name || !email || !phone) {
-      return NextResponse.json({ error: 'Falta uno de los campos son obligatorios' }, { status: 400 });
-    }
-
-    const existingPatient = await getPatientById(id);
-
-    if (existingPatient) {
-      const updatedPatient = await updatePatient(id, { name, email, phone });
-      return NextResponse.json(updatedPatient, { status: 200 });
-    } else {
-      const newPatient = await createPatient({ id, name, email, phone });
-      return NextResponse.json(newPatient, { status: 201 });
-    }
-  } catch (error) {
-    console.error(error);
-    return NextResponse.json({ error: 'Error saving patient ' + error }, { status: 500 });
-  }
-}
+});
 
 /**
  * DELETE method to remove a patient.
@@ -47,23 +45,18 @@ export async function POST(req) {
  * @param {NextApiRequest} req The Next.js API request object.
  * @returns {NextApiResponse} The response to be sent back to the client.
  */
-export async function DELETE(req) {
-  try {
-    const patientId = parseInt(req.nextUrl.pathname.split('/').pop());
+export const DELETE = withErrorHandling(async (req) => {
+  const patientId = parseInt(req.nextUrl.pathname.split('/').pop());
 
-    if (!patientId) {
-      return NextResponse.json({ error: 'Patient ID is required for deletion' }, { status: 400 });
-    }
-
-    const existingPatient = await getPatientById(patientId);
-    if (!existingPatient) {
-      return NextResponse.json({ error: 'Patient not found' }, { status: 404 });
-    }
-
-    const result = await deletePatient(patientId);
-    return NextResponse.json({ message: 'Patient successfully deleted', result }, { status: 200 });
-  } catch (error) {
-    console.error(error);
-    return NextResponse.json({ error: 'Error deleting patient: ' + error.message }, { status: 500 });
+  if (!patientId) {
+    throw new ValidationError('Patient ID is required for deletion');
   }
-}
+
+  const existingPatient = await getPatientById(patientId);
+  if (!existingPatient) {
+    return NextResponse.json({ error: 'Patient not found' }, { status: 404 });
+  }
+
+  const result = await deletePatient(patientId);
+  return NextResponse.json({ message: 'Patient successfully deleted', result }, { status: 200 });
+});


### PR DESCRIPTION
## Summary
- create validation and error-handler middleware
- use middleware in patient API route

## Testing
- `npm test` *(fails: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68677c1cc2288333925b1bcac429cba7