### PR TITLE
Fix TypeScript optional property errors

### DIFF
--- a/app/domain/entities/Category.ts
+++ b/app/domain/entities/Category.ts
@@ -6,6 +6,8 @@ export default class Category {
   constructor(id: number, name: string, studyTypes?: unknown[]) {
     this.id = id;
     this.name = name;
-    this.studyTypes = studyTypes;
+    if (studyTypes !== undefined) {
+      this.studyTypes = studyTypes;
+    }
   }
 }

--- a/app/domain/entities/MedicalReport.ts
+++ b/app/domain/entities/MedicalReport.ts
@@ -22,13 +22,24 @@ export default class MedicalReport {
     studies?: Study[];
     patientId: number;
   }) {
-    this.id = id;
-    this.name = patient?.name;
+    if (id !== undefined) {
+      this.id = id;
+    }
+    const patientName = patient?.name;
+    if (patientName !== undefined) {
+      this.name = patientName;
+    }
     this.date = date;
     this.status = status;
-    this.diagnosis = diagnosis ?? undefined;
-    this.patient = patient;
-    this.studies = studies;
+    if (diagnosis !== undefined) {
+      this.diagnosis = diagnosis;
+    }
+    if (patient !== undefined) {
+      this.patient = patient;
+    }
+    if (studies !== undefined) {
+      this.studies = studies;
+    }
     this.patientId = patientId;
   }
 

--- a/app/domain/entities/Patient.ts
+++ b/app/domain/entities/Patient.ts
@@ -17,8 +17,10 @@ export default class Patient {
     dateOfBirth: Date;
     gender: string;
     status: string;
-  }) {
-    this.id = id;
+    }) {
+    if (id !== undefined) {
+      this.id = id;
+    }
     this.name = name;
     this.email = email;
     this.phone = phone;

--- a/app/domain/entities/Study.ts
+++ b/app/domain/entities/Study.ts
@@ -21,14 +21,22 @@ export default class Study {
     medicalReport?: MedicalReport;
     status?: string;
   }) {
-    this.id = id;
+    if (id !== undefined) {
+      this.id = id;
+    }
     this.name = name;
     this.title = title;
     this.medicalReportId = medicalReportId;
     this.studyTypeId = studyTypeId;
-    this.type = type;
-    this.medicalReport = medicalReport;
-    this.status = status;
+    if (type !== undefined) {
+      this.type = type;
+    }
+    if (medicalReport !== undefined) {
+      this.medicalReport = medicalReport;
+    }
+    if (status !== undefined) {
+      this.status = status;
+    }
   }
 
   validate(): boolean {

--- a/app/domain/entities/StudyType.ts
+++ b/app/domain/entities/StudyType.ts
@@ -12,6 +12,8 @@ export default class StudyType {
     this.name = name;
     this.description = description;
     this.categoryId = categoryId;
-    this.category = category;
+    if (category !== undefined) {
+      this.category = category;
+    }
   }
 }

--- a/app/infrastructure/repositories/MedicalReportRepository.ts
+++ b/app/infrastructure/repositories/MedicalReportRepository.ts
@@ -1,7 +1,7 @@
 import { Prisma, PrismaClient } from '@prisma/client';
 import { BaseRepository } from './BaseRepository';
 
-export class MedicalReportRepository extends BaseRepository<Prisma.MedicalReportDelegate<Prisma.DefaultArgs>> {
+export class MedicalReportRepository extends BaseRepository<Prisma.MedicalReportDelegate> {
   constructor(prisma: PrismaClient) {
     super(prisma.medicalReport);
   }

--- a/app/infrastructure/repositories/PatientRepository.ts
+++ b/app/infrastructure/repositories/PatientRepository.ts
@@ -1,7 +1,7 @@
 import { Prisma, PrismaClient } from '@prisma/client';
 import { BaseRepository } from './BaseRepository';
 
-export class PatientRepository extends BaseRepository<Prisma.PatientDelegate<Prisma.DefaultArgs>> {
+export class PatientRepository extends BaseRepository<Prisma.PatientDelegate> {
   constructor(prisma: PrismaClient) {
     super(prisma.patient);
   }

--- a/app/infrastructure/repositories/StudyTypeRepository.ts
+++ b/app/infrastructure/repositories/StudyTypeRepository.ts
@@ -1,7 +1,7 @@
 import { Prisma, PrismaClient } from '@prisma/client';
 import { BaseRepository } from './BaseRepository';
 
-export class StudyTypeRepository extends BaseRepository<Prisma.StudyTypeDelegate<Prisma.DefaultArgs>> {
+export class StudyTypeRepository extends BaseRepository<Prisma.StudyTypeDelegate> {
   constructor(prisma: PrismaClient) {
     super(prisma.studyType);
   }

--- a/app/middleware/validation.ts
+++ b/app/middleware/validation.ts
@@ -8,7 +8,9 @@ export class ValidationError extends Error {
     super(message)
     this.name = 'ValidationError'
     this.status = 400
-    this.errors = errors
+    if (errors !== undefined) {
+      this.errors = errors
+    }
   }
 }
 

--- a/app/providers/APIProvider.ts
+++ b/app/providers/APIProvider.ts
@@ -15,7 +15,9 @@ export abstract class APIProvider {
   protected readonly db?: Database;
 
   constructor(db?: Database) {
-    this.db = db;
+    if (db !== undefined) {
+      this.db = db;
+    }
   }
 
   async fetchPatients(): Promise<Patient[]> {


### PR DESCRIPTION
## Summary
- guard assignments to optional properties in entities
- remove invalid Prisma generics from repositories
- handle optional values in validation and API provider

## Testing
- `npm run type-check`
- `npm test`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_b_686787c265148333870ab7830161a5b9