### PR TITLE
Fix import paths for legacy use cases

### DIFF
--- a/legacy_core/app/useCases/fetchCategories.js
+++ b/legacy_core/app/useCases/fetchCategories.js
@@ -1,5 +1,5 @@
 // useCases/fetchCategories.js
-import Category from '../../app/domain/entities/Category';
+import Category from '../../../app/domain/entities/Category';
 
 export async function fetchCategories() {
   try {

--- a/legacy_core/app/useCases/fetchMedicalReport.js
+++ b/legacy_core/app/useCases/fetchMedicalReport.js
@@ -1,5 +1,5 @@
 // useCases/fetchMedicalReport.js
-import MedicalReport from '../../app/domain/entities/MedicalReport';
+import MedicalReport from '../../../app/domain/entities/MedicalReport';
 
 export async function fetchMedicalReport(reportId) {
   try {

--- a/legacy_core/app/useCases/fetchMedicalReports.js
+++ b/legacy_core/app/useCases/fetchMedicalReports.js
@@ -1,5 +1,5 @@
 // useCases/fetchMedicalReports.js
-import MedicalReport from '../../app/domain/entities/MedicalReport';
+import MedicalReport from '../../../app/domain/entities/MedicalReport';
 
 export async function fetchMedicalReports() {
   try {

--- a/legacy_core/app/useCases/fetchPatients.js
+++ b/legacy_core/app/useCases/fetchPatients.js
@@ -1,5 +1,5 @@
 // useCases/fetchPatients.js
-import Patient from '../../app/domain/entities/Patient';
+import Patient from '../../../app/domain/entities/Patient';
 
 export async function fetchPatients() {
     try {

--- a/legacy_core/app/useCases/fetchStudyTypes.js
+++ b/legacy_core/app/useCases/fetchStudyTypes.js
@@ -1,5 +1,5 @@
 // useCases/fetchStudyTypes.js
-import StudyType from '../../app/domain/entities/StudyType';
+import StudyType from '../../../app/domain/entities/StudyType';
 
 export async function fetchStudyTypes() {
   try {

--- a/legacy_core/app/useCases/saveMedicalReport.js
+++ b/legacy_core/app/useCases/saveMedicalReport.js
@@ -1,4 +1,4 @@
-import MedicalReport from "../../app/domain/entities/MedicalReport";
+import MedicalReport from "../../../app/domain/entities/MedicalReport";
 
 export function saveMedicalReports(editedReport) {
   return new Promise(async (resolve, reject) => {

--- a/legacy_core/app/useCases/sendTokenByEmail.js
+++ b/legacy_core/app/useCases/sendTokenByEmail.js
@@ -1,4 +1,4 @@
-const MedicalReport = require('../../app/domain/entities/MedicalReport').default;
+const MedicalReport = require('../../../app/domain/entities/MedicalReport').default;
 import { sendEmail } from '../lib/mailer';
 import { format } from 'date-fns';
 


### PR DESCRIPTION
## Summary
- correct legacy Core use case import paths to point to main `app` domain entities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68678ae556908333950e22ac9f69fc07