### PR TITLE
Fix hydration mismatch for demo banner

### DIFF
--- a/app/components/DemoModeBanner.js
+++ b/app/components/DemoModeBanner.js
@@ -1,12 +1,18 @@
 "use client"
 import { useAppMode } from '../providers/AppModeProvider';
 import { useTranslation } from '../providers/I18nProvider';
+import { useEffect, useState } from 'react';
 
 export default function DemoModeBanner() {
   const { isDemoMode, toggleMode } = useAppMode();
   const { t } = useTranslation();
+  const [mounted, setMounted] = useState(false);
 
-  if (!isDemoMode) {
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted || !isDemoMode) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- ensure demo mode banner renders only after mount to avoid hydration issues

## Testing
- `npm test` *(fails: Unable to find expected text in HomePage and LandingPage tests)*
- `npm run lint` *(fails with TypeScript lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_6868cacc80b8833386742ffe5bb6aea4