### PR TITLE
Remove @ts-nocheck directives

### DIFF
--- a/src/store/middleware/auditMiddleware.ts
+++ b/src/store/middleware/auditMiddleware.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Audit logging middleware for medical compliance and security
 import type { AppState, MedicalStateAction } from '../types';
 

--- a/src/store/middleware/index.ts
+++ b/src/store/middleware/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Middleware factory functions - simplified implementations
 import type { AppState, MedicalStateAction, StoreConfig } from '../types';
 import { PerformanceManager } from '../utils/performanceManager';

--- a/src/store/middleware/storageMiddleware.ts
+++ b/src/store/middleware/storageMiddleware.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Storage middleware for state persistence between sessions
 import type { AppState, MedicalStateAction } from '../types';
 

--- a/src/store/reducers/consultationReducer.ts
+++ b/src/store/reducers/consultationReducer.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Consultation-specific reducer with optimized updates
 import type { 
   AppState, 

--- a/src/store/reducers/systemReducer.ts
+++ b/src/store/reducers/systemReducer.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // System-specific reducer for global application state
 import type { AppState, MedicalStateAction, MedicalError } from '../types';
 

--- a/src/store/reducers/userReducer.ts
+++ b/src/store/reducers/userReducer.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // User-specific reducer for preferences and statistics
 import type { AppState, MedicalStateAction } from '../types';
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Unified state management store with performance optimizations
 import { useMemo, useReducer, useCallback, useEffect, useRef, useState } from 'react';
 import type { 

--- a/src/store/utils/consultationUtils.ts
+++ b/src/store/utils/consultationUtils.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Utility functions for creating and managing consultation state
 import type { ConsultationState } from '../types';
 

--- a/src/store/utils/errorRecoveryManager.ts
+++ b/src/store/utils/errorRecoveryManager.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Advanced error recovery system with automatic retry strategies
 import type { MedicalError, MedicalStateAction } from '../types';
 

--- a/src/store/utils/performanceManager.ts
+++ b/src/store/utils/performanceManager.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Performance monitoring and optimization for mobile devices
 import type { PerformanceMetrics } from '../types';
 


### PR DESCRIPTION
## Summary
- clean up TypeScript `@ts-nocheck` directives in state management files

## Testing
- `npm run type-check` *(fails: Argument of type 'ErrorRecoveryManager | null' is not assignable to parameter of type 'ErrorRecoveryManager')*
- `npm run build` *(fails to compile TypeScript)*

------
https://chatgpt.com/codex/tasks/task_b_6868d276e10c83339e3aedaf7b308a2a