### PR TITLE
Improve responsive design for consultation workflow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -45,3 +45,29 @@ html.dark {
 body {
   @apply bg-gray-50 dark:bg-slate-900 text-gray-900 dark:text-gray-100;
 }
+
+.medical-assistant-container {
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+}
+
+@media (max-width: 768px) {
+  .medical-assistant-container {
+    padding: 0;
+    overflow-x: hidden;
+  }
+  .medical-assistant-container .header {
+    height: 60px;
+  }
+  .medical-assistant-container .chat-area {
+    padding: 1rem 0.75rem;
+  }
+  .medical-assistant-container .action-buttons {
+    flex-direction: row;
+    gap: 0.5rem;
+    padding: 0.75rem;
+  }
+}

--- a/src/components/ConsultationWorkspace.jsx
+++ b/src/components/ConsultationWorkspace.jsx
@@ -59,9 +59,9 @@ function ConsultationWorkspaceInner({ onExit }) {
   };
   
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50">
+    <div className="medical-assistant-container">
       {/* Header */}
-      <header className="bg-white/80 backdrop-blur-sm border-b border-white/50 px-6 py-4">
+      <header className="header bg-white/80 backdrop-blur-sm border-b border-white/50 px-6 py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-4">
             <button

--- a/src/components/consultation/AIAssistantPanel.jsx
+++ b/src/components/consultation/AIAssistantPanel.jsx
@@ -239,8 +239,8 @@ const AIAssistantPanel = () => {
   return (
     <div className="bg-white rounded-xl shadow-lg border border-gray-200 h-full flex flex-col">
       {/* Header */}
-      <div className="p-4 border-b border-gray-100">
-        <div className="flex items-center justify-between">
+      <div className="p-4 border-b border-gray-100 min-h-[60px] mobile-large:min-h-[80px]">
+        <div className="flex flex-col mobile-large:flex-row mobile-large:items-center mobile-large:justify-between gap-4">
           <div className="flex items-center space-x-3">
             <div className="w-10 h-10 bg-gradient-to-r from-purple-500 to-blue-500 rounded-xl flex items-center justify-center">
               <SparklesIcon className="w-6 h-6 text-white" />
@@ -292,7 +292,7 @@ const AIAssistantPanel = () => {
       </div>
       
       {/* Content Area */}
-      <div className="flex-1 overflow-hidden">
+      <div className="flex-1 overflow-hidden chat-area">
         <AnimatePresence mode="wait">
           {activeTab === 'chat' && (
             <motion.div
@@ -300,7 +300,7 @@ const AIAssistantPanel = () => {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -20 }}
-              className="h-full flex flex-col"
+              className="h-full flex flex-col max-h-[calc(100vh-160px)]"
             >
               {/* Messages */}
               <div className="flex-1 overflow-y-auto p-4 space-y-4">
@@ -388,7 +388,7 @@ const AIAssistantPanel = () => {
               </div>
               
               {/* Input */}
-              <div className="border-t border-gray-100 p-4">
+              <div className="border-t border-gray-100 p-4 sticky bottom-0 bg-white shadow-md">
                 <div className="flex items-end space-x-2">
                   <div className="flex-1">
                     <textarea
@@ -410,7 +410,7 @@ const AIAssistantPanel = () => {
                 </div>
                 
                 {/* Quick Actions */}
-                <div className="mt-3 flex flex-wrap gap-2">
+                <div className="mt-3 flex flex-row flex-wrap gap-2 action-buttons">
                   <button
                     onClick={() => handleSuggestionClick('Analizar síntomas principales')}
                     className="flex items-center px-3 py-1 text-xs bg-gray-100 text-gray-700 rounded-full hover:bg-gray-200 transition-colors"

--- a/src/components/consultation/DocumentationOutput.jsx
+++ b/src/components/consultation/DocumentationOutput.jsx
@@ -269,8 +269,8 @@ Generado con asistencia de IA médica - Revisar y validar contenido.`;
     <div className="p-6">
       <div className="max-w-6xl mx-auto">
         {/* Header */}
-        <div className="flex items-center justify-between mb-6">
-          <div className="flex items-center space-x-3">
+        <div className="flex items-center justify-between mb-6 sticky top-0 bg-white z-10 py-4">
+          <div className="flex items-center space-x-3 flex-wrap gap-2">
             <div className="w-10 h-10 bg-gradient-to-r from-green-500 to-blue-500 rounded-xl flex items-center justify-center">
               <DocumentTextIcon className="w-6 h-6 text-white" />
             </div>
@@ -282,28 +282,30 @@ Generado con asistencia de IA médica - Revisar y validar contenido.`;
             </div>
           </div>
           
-          <div className="flex items-center space-x-3">
-            {/* Auto-generate toggle */}
-            <label className="flex items-center space-x-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={autoGenerateEnabled}
-                onChange={(e) => setAutoGenerateEnabled(e.target.checked)}
-                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
-              <span className="text-sm text-gray-600">Auto-generar</span>
-            </label>
-            
-            {/* Manual generate button */}
-            <button
-              onClick={generateSOAPNotes}
-              disabled={!finalTranscript || isGeneratingSOAP}
-              className="flex items-center space-x-2 px-4 py-2 bg-blue-500 hover:bg-blue-600 disabled:bg-gray-300 text-white rounded-lg transition-colors text-sm"
-            >
-              <SparklesIcon className="w-4 h-4" />
-              <span>Generar SOAP</span>
-            </button>
-            
+          <div className="flex items-center space-x-3 flex-wrap gap-2">
+            <div className="flex items-center space-x-3">
+              {/* Auto-generate toggle */}
+              <label className="flex items-center space-x-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={autoGenerateEnabled}
+                  onChange={(e) => setAutoGenerateEnabled(e.target.checked)}
+                  className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="text-sm text-gray-600">Auto-generar</span>
+              </label>
+
+              {/* Manual generate button */}
+              <button
+                onClick={generateSOAPNotes}
+                disabled={!finalTranscript || isGeneratingSOAP}
+                className="flex items-center space-x-2 px-4 py-2 bg-blue-500 hover:bg-blue-600 disabled:bg-gray-300 text-white rounded-lg transition-colors text-sm"
+              >
+                <SparklesIcon className="w-4 h-4" />
+                <span>Generar SOAP</span>
+              </button>
+            </div>
+
             {/* Export controls */}
             {hasContent && (
               <>
@@ -314,7 +316,7 @@ Generado con asistencia de IA médica - Revisar y validar contenido.`;
                   <DocumentDuplicateIcon className="w-4 h-4" />
                   <span>Copiar</span>
                 </button>
-                
+
                 <button
                   onClick={exportToPDF}
                   className="flex items-center space-x-2 px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-lg transition-colors text-sm"
@@ -360,26 +362,28 @@ Generado con asistencia de IA médica - Revisar y validar contenido.`;
               const isEditing = editingSection === section;
               
               return (
-                <div
+                <details
                   key={section}
                   className={`rounded-lg border-2 ${getSectionColor(section)} transition-all duration-200`}
+                  open
                 >
-                  {/* Section Header */}
-                  <div className="p-4 border-b border-current border-opacity-20">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center space-x-2">
-                        <Icon className="w-5 h-5" />
-                        <h3 className="font-semibold">{getSectionTitle(section)}</h3>
-                      </div>
-                      <button
-                        onClick={() => setEditingSection(isEditing ? null : section)}
-                        className="p-1 hover:bg-white hover:bg-opacity-50 rounded transition-colors"
-                      >
-                        <PencilIcon className="w-4 h-4" />
-                      </button>
+                  <summary className="p-4 border-b border-current border-opacity-20 cursor-pointer flex items-center justify-between list-none">
+                    <div className="flex items-center space-x-2">
+                      <Icon className="w-5 h-5" />
+                      <h3 className="font-semibold">{getSectionTitle(section)}</h3>
                     </div>
-                  </div>
-                  
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setEditingSection(isEditing ? null : section);
+                      }}
+                      className="p-1 hover:bg-white hover:bg-opacity-50 rounded transition-colors"
+                    >
+                      <PencilIcon className="w-4 h-4" />
+                    </button>
+                  </summary>
+
                   {/* Section Content */}
                   <div className="p-4">
                     {isEditing ? (
@@ -414,7 +418,7 @@ Generado con asistencia de IA médica - Revisar y validar contenido.`;
                       </div>
                     )}
                   </div>
-                </div>
+                </details>
               );
             })}
           </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,12 @@ module.exports = {
   theme: {
     transparent: "transparent",
     current: "currentColor",
+    screens: {
+      "mobile-small": "320px",
+      "mobile-standard": "375px",
+      "mobile-large": "414px",
+      "tablet-medical": "768px",
+    },
     extend: {
       colors: {
         tremor: {


### PR DESCRIPTION
## Summary
- add medical mobile breakpoints in Tailwind config
- create `medical-assistant-container` styles
- refactor ConsultationWorkspace to use new container
- tweak AI assistant header, chat area and quick action buttons
- make documentation output header sticky and sections collapsible

## Testing
- `npm test` *(fails: 11 failed, 14 passed)*

------
https://chatgpt.com/codex/tasks/task_b_6868e103a0d88333b37ee56703bf0e3f