### PR TITLE
Add medical microinteraction framework

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -71,3 +71,79 @@ body {
     padding: 0.75rem;
   }
 }
+.medical-bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 70px;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid #e2e8f0;
+  z-index: 1000;
+}
+.medical-bottom-nav .nav-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  transition: all 0.3s ease;
+}
+.medical-bottom-nav .nav-item.active {
+  color: #3b82f6;
+  transform: translateY(-2px);
+}
+.medical-bottom-nav .nav-item.active .nav-icon {
+  transform: scale(1.1);
+}
+.medical-bottom-nav .nav-item .nav-icon {
+  font-size: 20px;
+  margin-bottom: 4px;
+  transition: all 0.2s ease;
+}
+.medical-bottom-nav .nav-item .nav-label {
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.medical-notification {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  max-width: 350px;
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 10px 25px rgba(0,0,0,0.15);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  z-index: 9999;
+}
+.medical-notification.show { transform: translateX(0); }
+.medical-notification--critical {
+  background: linear-gradient(135deg, #dc2626, #b91c1c);
+  color: white;
+  border-left: 4px solid #7f1d1d;
+  animation: criticalPulse 1s infinite;
+}
+.medical-notification--warning {
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+  color: white;
+  border-left: 4px solid #92400e;
+}
+.medical-notification--success {
+  background: linear-gradient(135deg, #10b981, #059669);
+  color: white;
+  border-left: 4px solid #047857;
+}
+.medical-notification--info {
+  background: linear-gradient(135deg, #3b82f6, #2563eb);
+  color: white;
+  border-left: 4px solid #1d4ed8;
+}
+@keyframes criticalPulse {
+  0%,100%{transform:scale(1) translateX(0);}
+  50%{transform:scale(1.02) translateX(0);}
+}

--- a/src/components/MedicalBottomNav.tsx
+++ b/src/components/MedicalBottomNav.tsx
@@ -1,0 +1,65 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { BottomNavItem } from "../types/medicalUI";
+import { FaUserMd, FaBrain, FaFolderOpen, FaGear } from "react-icons/fa6";
+
+const navItems: BottomNavItem[] = [
+  {
+    id: "dashboard",
+    label: "Pacientes",
+    icon: "users-medical",
+    route: "/dashboard",
+    badge: null,
+  },
+  {
+    id: "ai-assistant",
+    label: "Asistente IA",
+    icon: "brain",
+    route: "/chat",
+    badge: null,
+  },
+  {
+    id: "records",
+    label: "Expedientes",
+    icon: "folder-medical",
+    route: "/records",
+    badge: null,
+  },
+  {
+    id: "settings",
+    label: "Configuración",
+    icon: "gear-medical",
+    route: "/settings",
+    badge: null,
+  },
+];
+
+const iconMap: Record<string, any> = {
+  "users-medical": FaUserMd,
+  brain: FaBrain,
+  "folder-medical": FaFolderOpen,
+  "gear-medical": FaGear,
+};
+
+export default function MedicalBottomNav() {
+  const pathname = usePathname();
+  return (
+    <nav className="medical-bottom-nav flex justify-around">
+      {navItems.map((item) => {
+        const active = pathname === item.route;
+        const Icon = iconMap[item.icon] || FaUserMd;
+        return (
+          <Link
+            key={item.id}
+            href={item.route}
+            className={`nav-item ${active ? "active" : ""}`}
+          >
+            <Icon className="nav-icon" />
+            <span className="nav-label">{item.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/MedicalLoading.tsx
+++ b/src/components/MedicalLoading.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { motion } from "framer-motion";
+import { medicalLoadingStates } from "../utils/medicalLoadingStates";
+
+const iconMap: Record<string, React.ElementType> = {
+  "brain-circuit": () => <span className="nav-icon">🧠</span>,
+  stethoscope: () => <span className="nav-icon">🩺</span>,
+  "file-medical": () => <span className="nav-icon">📄</span>,
+  heartbeat: () => <span className="nav-icon">❤️</span>,
+};
+
+export default function MedicalLoading({
+  state,
+}: {
+  state: keyof typeof medicalLoadingStates;
+}) {
+  const config = medicalLoadingStates[state];
+  const Icon = iconMap[config.icon] || iconMap["brain-circuit"];
+
+  return (
+    <div className="flex flex-col items-center p-4 animate-pulse">
+      <Icon />
+      <p className="text-sm text-gray-600 mb-2">{config.text}</p>
+      <div className="w-full h-2 bg-blue-100 rounded-full overflow-hidden">
+        <motion.div
+          className="h-full bg-blue-500"
+          initial={{ width: "0%" }}
+          animate={{ width: "100%" }}
+          transition={{ duration: 2 }}
+        />
+      </div>
+      <div className="mt-4 space-y-2 w-full">
+        <div className="h-3 bg-blue-100 rounded w-3/4" />
+        <div className="h-3 bg-blue-100 rounded w-1/2" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/MedicalNotification.tsx
+++ b/src/components/MedicalNotification.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { NotificationVariant } from "../types/medicalUI";
+import { useEffect, useState } from "react";
+
+interface Props {
+  variant: NotificationVariant;
+  message: string;
+  show: boolean;
+}
+
+export default function MedicalNotification({ variant, message, show }: Props) {
+  const [visible, setVisible] = useState(show);
+  useEffect(() => setVisible(show), [show]);
+
+  return (
+    <div
+      className={`medical-notification medical-notification--${variant} ${visible ? "show" : ""}`}
+      role="alert"
+    >
+      {message}
+    </div>
+  );
+}

--- a/src/components/QuickMedicalActions.tsx
+++ b/src/components/QuickMedicalActions.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { QuickAction } from "../types/medicalUI";
+import {
+  FaHeartbeat,
+  FaPrescriptionBottleAlt,
+  FaCalendarCheck,
+  FaSirenOn,
+} from "react-icons/fa6";
+
+const actions: QuickAction[] = [
+  {
+    id: "vital-signs",
+    label: "Signos Vitales",
+    icon: "heart-pulse",
+    color: "#ef4444",
+    action: () => (window as any).openVitalSignsModal?.(),
+  },
+  {
+    id: "prescription",
+    label: "Nueva Receta",
+    icon: "prescription",
+    color: "#10b981",
+    action: () => (window as any).openPrescriptionForm?.(),
+  },
+  {
+    id: "follow-up",
+    label: "Seguimiento",
+    icon: "calendar-check",
+    color: "#f59e0b",
+    action: () => (window as any).scheduleFollowUp?.(),
+  },
+  {
+    id: "emergency",
+    label: "Emergencia",
+    icon: "siren",
+    color: "#dc2626",
+    action: () => (window as any).triggerEmergencyProtocol?.(),
+  },
+];
+
+const iconMap: Record<string, any> = {
+  "heart-pulse": FaHeartbeat,
+  prescription: FaPrescriptionBottleAlt,
+  "calendar-check": FaCalendarCheck,
+  siren: FaSirenOn,
+};
+
+export default function QuickMedicalActions() {
+  return (
+    <div className="fixed bottom-24 right-4 flex flex-col items-end space-y-3 z-50">
+      {actions.map((act) => {
+        const Icon = iconMap[act.icon];
+        return (
+          <button
+            key={act.id}
+            onClick={act.action}
+            style={{ background: act.color }}
+            className="w-12 h-12 rounded-full text-white flex items-center justify-center shadow-lg"
+          >
+            <Icon className="w-5 h-5" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/types/medicalUI.ts
+++ b/src/types/medicalUI.ts
@@ -1,0 +1,18 @@
+export interface BottomNavItem {
+  id: string;
+  label: string;
+  icon: string;
+  route: string;
+  badge?: number | null;
+  isActive?: boolean;
+}
+
+export interface QuickAction {
+  id: string;
+  label: string;
+  icon: string;
+  color: string;
+  action: () => void;
+}
+
+export type NotificationVariant = "critical" | "warning" | "success" | "info";

--- a/src/utils/medicalGestures.ts
+++ b/src/utils/medicalGestures.ts
@@ -1,0 +1,20 @@
+import { medicalHaptics } from "./medicalHaptics";
+
+export const medicalGestures = {
+  swipeRight: (element: HTMLElement) => {
+    element.style.background = "#10b981";
+    medicalHaptics.success();
+  },
+  swipeLeft: (element: HTMLElement) => {
+    element.style.background = "#f59e0b";
+    medicalHaptics.warning();
+  },
+  longPress: (element: HTMLElement, duration = 800) => {
+    setTimeout(() => {
+      medicalHaptics.processing();
+      if (typeof (window as any).showAdvancedOptions === "function") {
+        (window as any).showAdvancedOptions(element);
+      }
+    }, duration);
+  },
+};

--- a/src/utils/medicalHaptics.ts
+++ b/src/utils/medicalHaptics.ts
@@ -1,0 +1,23 @@
+export const medicalHaptics = {
+  success: () => {
+    if (typeof navigator !== "undefined" && navigator.vibrate) {
+      navigator.vibrate(100);
+    }
+  },
+  warning: () => {
+    if (typeof navigator !== "undefined" && navigator.vibrate) {
+      navigator.vibrate([50, 100, 50]);
+    }
+  },
+  critical: () => {
+    if (typeof navigator !== "undefined" && navigator.vibrate) {
+      navigator.vibrate([100, 50, 100, 50, 200]);
+    }
+  },
+  processing: () => {
+    if (typeof navigator !== "undefined" && navigator.vibrate) {
+      const interval = setInterval(() => navigator.vibrate(30), 2000);
+      setTimeout(() => clearInterval(interval), 10000);
+    }
+  },
+};

--- a/src/utils/medicalLoadingStates.ts
+++ b/src/utils/medicalLoadingStates.ts
@@ -1,0 +1,28 @@
+export interface LoadingStateConfig {
+  text: string;
+  duration: string;
+  icon: string;
+}
+
+export const medicalLoadingStates: Record<string, LoadingStateConfig> = {
+  "analyzing-symptoms": {
+    text: "Analizando síntomas del paciente...",
+    duration: "2-3 segundos",
+    icon: "brain-circuit",
+  },
+  "generating-diagnosis": {
+    text: "Generando diagnóstico diferencial...",
+    duration: "3-5 segundos",
+    icon: "stethoscope",
+  },
+  "creating-soap": {
+    text: "Estructurando nota SOAP...",
+    duration: "1-2 segundos",
+    icon: "file-medical",
+  },
+  "processing-vitals": {
+    text: "Procesando signos vitales...",
+    duration: "1 segundo",
+    icon: "heartbeat",
+  },
+};


### PR DESCRIPTION
## Summary
- implement medical loading state configs
- add medical haptic feedback and gesture utilities
- create medical bottom navigation and quick actions components
- provide medical notification and loading indicator components
- style bottom nav and notifications in global CSS

## Testing
- `npm test` *(fails: 11 failed, 14 passed)*

------
https://chatgpt.com/codex/tasks/task_b_6868e94b32908333ac803bd4d0192c9c