### PR TITLE
Fix extra closing div causing syntax error

### DIFF
--- a/src/components/consultation/TranscriptionPanel.jsx
+++ b/src/components/consultation/TranscriptionPanel.jsx
@@ -329,7 +329,6 @@ const TranscriptionPanel = () => {
             }`} />
           </div>
         </div>
-      </div>
       
       {/* Recording Controls */}
       <div className="transcription-content">


### PR DESCRIPTION
## Summary
- fix an unmatched closing `div` in `TranscriptionPanel.jsx`

## Testing
- `npm test` *(fails: Jest tests)*
- `npm run build` *(fails: network fetch for fonts)*

------
https://chatgpt.com/codex/tasks/task_b_6869625b58c883338132c86b090603ff