### PR TITLE
Fix demo dashboard detection

### DIFF
--- a/src/components/MinimalistLandingPage.jsx
+++ b/src/components/MinimalistLandingPage.jsx
@@ -14,9 +14,11 @@ import dynamic from 'next/dynamic';
 const DemoLoginModal = dynamic(() => import('../../components/DemoLoginModal'));
 const DashboardLanding = dynamic(() => import('./DashboardLanding'));
 import { useTranslation } from '../../app/providers/I18nProvider';
+import { useAppMode } from '../../app/providers/AppModeProvider';
 
 const MinimalistLandingPage = ({ isDemo = false }) => {
-  const isDemoMode = isDemo;
+  const { isDemoMode: contextDemo } = useAppMode();
+  const isDemoMode = isDemo || contextDemo;
 
   const { t } = useTranslation();
 


### PR DESCRIPTION
## Summary
- always read app mode from context in MinimalistLandingPage so `?demo=true` properly displays the demo dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6869ef123fdc8333aae0e8fc0b563212