### PR TITLE
Reduce vendor weight by removing react-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-hot-toast": "2.5.2",
-    "react-icons": "4.12.0",
     "react-loader-spinner": "6.1.6",
     "react-slick": "0.29.0",
     "resend": "2.1.0",

--- a/src/components/LandingPageStrategy.jsx
+++ b/src/components/LandingPageStrategy.jsx
@@ -1,7 +1,8 @@
 "use client";
 import React from 'react';
-import CinematicLandingPage from './CinematicLandingPage';
-import MinimalistLandingPage from './MinimalistLandingPage';
+import dynamic from 'next/dynamic';
+const CinematicLandingPage = dynamic(() => import('./CinematicLandingPage'), { ssr: false });
+const MinimalistLandingPage = dynamic(() => import('./MinimalistLandingPage'));
 
 const LANDING_PAGE_TYPES = {
   CINEMATIC: 'cinematic',

--- a/src/components/MedicalBottomNav.tsx
+++ b/src/components/MedicalBottomNav.tsx
@@ -2,46 +2,41 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { BottomNavItem } from "../types/medicalUI";
-import { FaUserDoctor, FaBrain, FaFolderOpen, FaGear } from "react-icons/fa6";
-type IconComponent = (props: { className?: string }) => JSX.Element;
+// use simple emoji strings instead of react-icons
+interface BottomNavItemWithEmoji extends BottomNavItem {
+  emoji: string;
+}
 
-const navItems: BottomNavItem[] = [
+const navItems: BottomNavItemWithEmoji[] = [
   {
     id: "dashboard",
     label: "Pacientes",
-    icon: "users-medical",
+    emoji: "👥",
     route: "/dashboard",
     badge: null,
   },
   {
     id: "ai-assistant",
     label: "Asistente IA",
-    icon: "brain",
+    emoji: "🧠",
     route: "/chat",
     badge: null,
   },
   {
     id: "records",
     label: "Expedientes",
-    icon: "folder-medical",
+    emoji: "📂",
     route: "/records",
     badge: null,
   },
   {
     id: "settings",
     label: "Configuración",
-    icon: "gear-medical",
+    emoji: "⚙️",
     route: "/settings",
     badge: null,
   },
 ];
-
-const iconMap: Record<string, IconComponent> = {
-  "users-medical": FaUserDoctor as IconComponent,
-  brain: FaBrain as IconComponent,
-  "folder-medical": FaFolderOpen as IconComponent,
-  "gear-medical": FaGear as IconComponent,
-};
 
 export default function MedicalBottomNav() {
   const pathname = usePathname();
@@ -49,14 +44,15 @@ export default function MedicalBottomNav() {
     <nav className="medical-bottom-nav flex justify-around">
       {navItems.map((item) => {
         const active = pathname === item.route;
-        const Icon = iconMap[item.icon] || FaUserDoctor;
         return (
           <Link
             key={item.id}
             href={item.route}
             className={`nav-item ${active ? "active" : ""}`}
           >
-            <Icon className="nav-icon" />
+            <span className="nav-icon" role="img" aria-hidden="true">
+              {item.emoji}
+            </span>
             <span className="nav-label">{item.label}</span>
           </Link>
         );

--- a/src/components/QuickMedicalActions.tsx
+++ b/src/components/QuickMedicalActions.tsx
@@ -1,67 +1,56 @@
 "use client";
 import { QuickAction } from "../types/medicalUI";
-import {
-  FaHeartPulse,
-  FaPrescriptionBottleMedical,
-  FaCalendarCheck,
-  FaBell,
-} from "react-icons/fa6";
-type IconComponent = (props: { className?: string }) => JSX.Element;
+// replace heavy icon library with simple emoji rendering
+interface ActionWithEmoji extends QuickAction {
+  emoji: string;
+}
 
-const actions: QuickAction[] = [
+const actions: ActionWithEmoji[] = [
   {
     id: "vital-signs",
     label: "Signos Vitales",
-    icon: "heart-pulse",
+    emoji: "❤️",
     color: "#ef4444",
     action: () => window.openVitalSignsModal?.(),
   },
   {
     id: "prescription",
     label: "Nueva Receta",
-    icon: "prescription",
+    emoji: "💊",
     color: "#10b981",
     action: () => window.openPrescriptionForm?.(),
   },
   {
     id: "follow-up",
     label: "Seguimiento",
-    icon: "calendar-check",
+    emoji: "📅",
     color: "#f59e0b",
     action: () => window.scheduleFollowUp?.(),
   },
   {
     id: "emergency",
     label: "Emergencia",
-    icon: "siren",
+    emoji: "🚨",
     color: "#dc2626",
     action: () => window.triggerEmergencyProtocol?.(),
   },
 ];
 
-const iconMap: Record<string, IconComponent> = {
-  "heart-pulse": FaHeartPulse as IconComponent,
-  prescription: FaPrescriptionBottleMedical as IconComponent,
-  "calendar-check": FaCalendarCheck as IconComponent,
-  siren: FaBell as IconComponent,
-};
-
 export default function QuickMedicalActions() {
   return (
     <div className="fixed bottom-24 right-4 flex flex-col items-end space-y-3 z-50">
-      {actions.map((act) => {
-        const Icon = iconMap[act.icon];
-        return (
-          <button
-            key={act.id}
-            onClick={act.action}
-            style={{ background: act.color }}
-            className="w-12 h-12 rounded-full text-white flex items-center justify-center shadow-lg"
-          >
-            <Icon className="w-5 h-5" />
-          </button>
-        );
-      })}
+      {actions.map((act) => (
+        <button
+          key={act.id}
+          onClick={act.action}
+          style={{ background: act.color }}
+          className="w-12 h-12 rounded-full text-white flex items-center justify-center shadow-lg"
+        >
+          <span role="img" aria-hidden="true" className="text-lg">
+            {act.emoji}
+          </span>
+        </button>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- drop `react-icons` from dependencies
- replace medical icons with emojis
- lazy load heavy CinematicLandingPage

## Testing
- `npm test` *(fails: Request is not defined; accessibility contrast tests fail; Layout.test crashes)*

------
https://chatgpt.com/codex/tasks/task_b_686b160d3bc883339df5404035bfa4b1