### PR TITLE
Improve error logging for API failures

### DIFF
--- a/app/services/MedicalAILogic.js
+++ b/app/services/MedicalAILogic.js
@@ -67,9 +67,21 @@ async function makeAIRequest(model, body, { config, httpClient }) {
   });
 
   if (!response.ok) {
-    const error = new Error(await response.text());
+    const errorText = await response.text();
+    console.error('[API ERROR]', {
+      endpoint: `${config.getBaseUrl()}/${model}`,
+      status: response.status,
+      method: 'POST',
+      requestBody: body,
+      responseBody: errorText,
+      time: new Date().toISOString(),
+      stack: new Error().stack,
+    });
+
+    const error = new Error(`[API ERROR ${response.status}] ${(response.statusText || 'Error')}: ${errorText}`);
     error.status = response.status;
     error.type = getErrorType(response.status);
+    error.response = errorText;
     throw error;
   }
 

--- a/src/store/middleware/auditMiddleware.ts
+++ b/src/store/middleware/auditMiddleware.ts
@@ -551,7 +551,19 @@ export class AuditMiddleware {
       });
       
       if (!response.ok) {
-        throw new Error(`Audit log upload failed: ${response.status}`);
+        const errorText = await response.text();
+        console.error('[API ERROR]', {
+          endpoint: this.config.remoteEndpoint || 'audit-endpoint',
+          status: response.status,
+          method: 'POST',
+          requestBody: { sessionId: this.sessionId, events },
+          responseBody: errorText,
+          time: new Date().toISOString(),
+          stack: new Error().stack,
+        });
+
+        const statusText = response.statusText || 'Error';
+        throw new Error(`[API ERROR ${response.status}] ${statusText}: ${errorText}`);
       }
       
     } catch (error) {

--- a/tests/services/MedicalAILogic.test.js
+++ b/tests/services/MedicalAILogic.test.js
@@ -1,5 +1,14 @@
 import { processMedicalQuery, getErrorMessage, getAvailableTypes } from '../../app/services/MedicalAILogic.js';
 
+// Polyfill AbortSignal.timeout for test environment
+if (typeof AbortSignal !== 'undefined' && !AbortSignal.timeout) {
+  AbortSignal.timeout = function (ms) {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), ms);
+    return controller.signal;
+  };
+}
+
 // Mock dependencies
 const mockConfig = {
   validateConfig: jest.fn(() => []),
@@ -85,7 +94,7 @@ describe('MedicalAILogic', () => {
           { config: mockConfig, httpClient: mockHttpClient }
         )
       ).rejects.toMatchObject({
-        message: 'Unauthorized',
+        message: '[API ERROR 401] Error: Unauthorized',
         status: 401,
         type: 'authentication_error'
       });

--- a/tests/utils/medicalUtils.test.js
+++ b/tests/utils/medicalUtils.test.js
@@ -46,13 +46,14 @@ describe('mockMedicalAI.generateResponse', () => {
   });
 
   it('should handle authentication error (401) correctly', async () => {
+    const mockError = {
+      error: 'Invalid Hugging Face token',
+      type: 'authentication_error'
+    };
     const mockResponse = {
       ok: false,
       status: 401,
-      json: jest.fn().mockResolvedValue({
-        error: 'Invalid Hugging Face token',
-        type: 'authentication_error'
-      })
+      text: jest.fn().mockResolvedValue(JSON.stringify(mockError))
     };
     global.fetch.mockResolvedValue(mockResponse);
 
@@ -64,13 +65,14 @@ describe('mockMedicalAI.generateResponse', () => {
   });
 
   it('should handle configuration error correctly', async () => {
+    const mockError = {
+      error: 'Hugging Face token not configured',
+      type: 'configuration_error'
+    };
     const mockResponse = {
       ok: false,
       status: 500,
-      json: jest.fn().mockResolvedValue({
-        error: 'Hugging Face token not configured',
-        type: 'configuration_error'
-      })
+      text: jest.fn().mockResolvedValue(JSON.stringify(mockError))
     };
     global.fetch.mockResolvedValue(mockResponse);
 
@@ -82,13 +84,14 @@ describe('mockMedicalAI.generateResponse', () => {
   });
 
   it('should handle rate limit error (429) correctly', async () => {
+    const mockError = {
+      error: 'Rate limit exceeded',
+      type: 'rate_limit_error'
+    };
     const mockResponse = {
       ok: false,
       status: 429,
-      json: jest.fn().mockResolvedValue({
-        error: 'Rate limit exceeded',
-        type: 'rate_limit_error'
-      })
+      text: jest.fn().mockResolvedValue(JSON.stringify(mockError))
     };
     global.fetch.mockResolvedValue(mockResponse);
 
@@ -103,9 +106,7 @@ describe('mockMedicalAI.generateResponse', () => {
     const mockResponse = {
       ok: false,
       status: 500,
-      json: jest.fn().mockResolvedValue({
-        error: 'Internal server error'
-      })
+      text: jest.fn().mockResolvedValue('Internal server error')
     };
     global.fetch.mockResolvedValue(mockResponse);
 


### PR DESCRIPTION
## Summary
- log full API error context in medicalUtils and audit middleware
- add detailed error logs in MedicalAILogic
- adapt tests for new error handling
- polyfill `AbortSignal.timeout` for tests

## Testing
- `npm test tests/utils/medicalUtils.test.js`
- `npm test tests/services/MedicalAILogic.test.js`
- `npm test` *(fails: Request is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_686b45fe58608333952455852f4f456f