### PR TITLE
fix(security): tighten CORS policy

### DIFF
--- a/microservice.config.js
+++ b/microservice.config.js
@@ -60,7 +60,11 @@ export const microserviceConfig = {
   security: {
     cors: {
       enabled: true,
-      origins: process.env.ALLOWED_ORIGINS?.split(',') || ['*']
+      origins:
+        process.env.ALLOWED_ORIGINS?.split(',') || [
+          'https://symfarmia.netlify.app',
+          'http://localhost:3000'
+        ]
     },
     authentication: {
       required: false, // Internal service

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const allowed = (process.env.ALLOWED_ORIGINS ?? 'https://symfarmia.netlify.app,http://localhost:3000')
+  .split(',')
+  .map(origin => origin.trim())
+  .filter(Boolean)
+
+export function middleware(req: NextRequest) {
+  const origin = req.headers.get('origin')
+  if (origin && !allowed.includes(origin)) {
+    return new NextResponse('Forbidden', { status: 403 })
+  }
+
+  const res = NextResponse.next()
+  if (origin && allowed.includes(origin)) {
+    res.headers.set('Access-Control-Allow-Origin', origin)
+    res.headers.set('Vary', 'Origin')
+  }
+
+  if (req.method === 'OPTIONS') {
+    res.headers.set('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS')
+    res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+    return res
+  }
+
+  return res
+}
+
+export const config = {
+  matcher: '/api/:path*',
+}


### PR DESCRIPTION
## Summary
- restrict microservice CORS configuration
- add middleware to enforce trusted origins for API routes

## Testing
- `npm test` *(fails: Cannot find module '@auth0/nextjs-auth0/client')*

------
https://chatgpt.com/codex/tasks/task_b_686b65df19008333a01e073877c7a943