### PR TITLE
Fix accessibility contrast issue

### DIFF
--- a/scripts/check-accessibility.js
+++ b/scripts/check-accessibility.js
@@ -25,7 +25,7 @@ const colorTests = [
   { bg: '#1f2937', text: '#9ca3af', name: 'Dark mode - Muted text' },
   { bg: '#111827', text: '#ffffff', name: 'Dark mode - Modal background' },
   { bg: '#2563eb', text: '#ffffff', name: 'Dark mode - Primary button' },
-  { bg: '#1f2937', text: '#6b7280', name: 'Dark mode - Input border' },
+  { bg: '#1f2937', text: '#9ca3af', name: 'Dark mode - Input border' },
 ];
 
 // WCAG AA standards

--- a/src/components/AIChat.jsx
+++ b/src/components/AIChat.jsx
@@ -181,7 +181,7 @@ const AIChat = () => {
                       <button
                         key={index}
                         onClick={() => handleSuggestionClick(suggestion)}
-                        className="block w-full text-left px-3 py-2 text-xs bg-white dark:bg-slate-600 border border-gray-200 dark:border-gray-500 rounded-md hover:bg-gray-50 dark:hover:bg-slate-500 transition-colors"
+                        className="block w-full text-left px-3 py-2 text-xs bg-white dark:bg-slate-600 border border-gray-200 dark:border-gray-400 rounded-md hover:bg-gray-50 dark:hover:bg-slate-500 transition-colors"
                       >
                         {suggestion}
                       </button>


### PR DESCRIPTION
## Summary
- use higher contrast border in AI chat suggestions
- update color tests to match new border color
- run accessibility scan

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '@auth0/nextjs-auth0/client')*
- `node scripts/check-accessibility.js`

------
https://chatgpt.com/codex/tasks/task_b_686b747a47848333ae7cf63cc3a87131