### PR TITLE
feat(prisma): reactivate models and expose full CRUD in dashboard

### DIFF
--- a/app/api/categories/[id]/route.ts
+++ b/app/api/categories/[id]/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { createDatabase } from '@/app/infrastructure/database';
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const { categoryRepository } = createDatabase();
+  const id = parseInt(params.id);
+  await categoryRepository.deleteCategory(id);
+  return NextResponse.json({ success: true }, { status: 200 });
+}

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { createDatabase } from '@/app/infrastructure/database';
+
+export async function GET() {
+  const { categoryRepository } = createDatabase();
+  const categories = await categoryRepository.getAllCategories();
+  return NextResponse.json(categories, { status: 200 });
+}
+
+export async function POST(request: Request) {
+  const { categoryRepository } = createDatabase();
+  const data = await request.json();
+  if (data.id) {
+    const category = await categoryRepository.updateCategory(data.id, data);
+    return NextResponse.json(category, { status: 200 });
+  }
+  const category = await categoryRepository.createCategory(data);
+  return NextResponse.json(category, { status: 201 });
+}

--- a/app/api/medicalReports/[id]/route.ts
+++ b/app/api/medicalReports/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { createDatabase } from '@/app/infrastructure/database';
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const { medicalReportRepository } = createDatabase();
+  const id = parseInt(params.id);
+  const report = await medicalReportRepository.getMedicalReportById(id);
+  if (!report) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json(report, { status: 200 });
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const { medicalReportRepository } = createDatabase();
+  const id = parseInt(params.id);
+  await medicalReportRepository.deleteMedicalReport(id);
+  return NextResponse.json({ success: true }, { status: 200 });
+}

--- a/app/api/medicalReports/route.ts
+++ b/app/api/medicalReports/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { createDatabase } from '@/app/infrastructure/database';
+
+export async function GET() {
+  const { medicalReportRepository } = createDatabase();
+  const reports = await medicalReportRepository.getAllMedicalReports();
+  return NextResponse.json(reports, { status: 200 });
+}
+
+export async function POST(request: Request) {
+  const { medicalReportRepository } = createDatabase();
+  const data = await request.json();
+  if (data.id) {
+    const report = await medicalReportRepository.updateMedicalReport(data.id, data);
+    return NextResponse.json(report, { status: 200 });
+  }
+  const report = await medicalReportRepository.createMedicalReport(data);
+  return NextResponse.json(report, { status: 201 });
+}

--- a/app/api/patients/[id]/route.ts
+++ b/app/api/patients/[id]/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { createDatabase } from '@/app/infrastructure/database';
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const { patientRepository } = createDatabase();
+  const id = parseInt(params.id);
+  await patientRepository.deletePatient(id);
+  return NextResponse.json({ success: true }, { status: 200 });
+}

--- a/app/api/patients/route.ts
+++ b/app/api/patients/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { createDatabase } from '@/app/infrastructure/database';
+
+export async function GET() {
+  const { patientRepository } = createDatabase();
+  const patients = await patientRepository.getAllPatients();
+  return NextResponse.json(patients, { status: 200 });
+}
+
+export async function POST(request: Request) {
+  const { patientRepository } = createDatabase();
+  const data = await request.json();
+  if (data.id) {
+    const patient = await patientRepository.updatePatient(data.id, data);
+    return NextResponse.json(patient, { status: 200 });
+  }
+  const patient = await patientRepository.createPatient(data);
+  return NextResponse.json(patient, { status: 201 });
+}

--- a/app/api/studies/[id]/route.ts
+++ b/app/api/studies/[id]/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { createDatabase } from '@/app/infrastructure/database';
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const { studyRepository } = createDatabase();
+  const id = parseInt(params.id);
+  await studyRepository.deleteStudy(id);
+  return NextResponse.json({ success: true }, { status: 200 });
+}

--- a/app/api/studies/route.ts
+++ b/app/api/studies/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { createDatabase } from '@/app/infrastructure/database';
+
+export async function GET() {
+  const { studyRepository } = createDatabase();
+  const studies = await studyRepository.getAllStudies();
+  return NextResponse.json(studies, { status: 200 });
+}
+
+export async function POST(request: Request) {
+  const { studyRepository } = createDatabase();
+  const data = await request.json();
+  if (data.id) {
+    const study = await studyRepository.updateStudy(data.id, data);
+    return NextResponse.json(study, { status: 200 });
+  }
+  const study = await studyRepository.createStudy(data);
+  return NextResponse.json(study, { status: 201 });
+}

--- a/app/api/study-types/[id]/route.ts
+++ b/app/api/study-types/[id]/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { createDatabase } from '@/app/infrastructure/database';
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const { studyTypeRepository } = createDatabase();
+  const id = parseInt(params.id);
+  await studyTypeRepository.deleteStudyType(id);
+  return NextResponse.json({ success: true }, { status: 200 });
+}

--- a/app/api/study-types/route.ts
+++ b/app/api/study-types/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { createDatabase } from '@/app/infrastructure/database';
+
+export async function GET() {
+  const { studyTypeRepository } = createDatabase();
+  const types = await studyTypeRepository.getAllStudyTypes();
+  return NextResponse.json(types, { status: 200 });
+}
+
+export async function POST(request: Request) {
+  const { studyTypeRepository } = createDatabase();
+  const data = await request.json();
+  if (data.id) {
+    const type = await studyTypeRepository.updateStudyType(data.id, data);
+    return NextResponse.json(type, { status: 200 });
+  }
+  const type = await studyTypeRepository.createStudyType(data);
+  return NextResponse.json(type, { status: 201 });
+}

--- a/app/dashboard/categories/page.tsx
+++ b/app/dashboard/categories/page.tsx
@@ -1,0 +1,4 @@
+import ModelManager from '@/components/ModelManager';
+export default function CategoriesPage() {
+  return <ModelManager endpoint="/api/categories" fields={["name"]} title="Categories" />;
+}

--- a/app/dashboard/medicalReports/page.tsx
+++ b/app/dashboard/medicalReports/page.tsx
@@ -1,0 +1,4 @@
+import ModelManager from '@/components/ModelManager';
+export default function MedicalReportsPage() {
+  return <ModelManager endpoint="/api/medicalReports" fields={["patientId","diagnosis","status"]} title="Medical Reports" />;
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+
+export default function DashboardPage() {
+  const links = [
+    { href: '/dashboard/patients', label: 'Patients' },
+    { href: '/dashboard/medicalReports', label: 'Medical Reports' },
+    { href: '/dashboard/categories', label: 'Categories' },
+    { href: '/dashboard/study-types', label: 'Study Types' },
+    { href: '/dashboard/studies', label: 'Studies' },
+  ];
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <ul className="space-y-2">
+        {links.map(link => (
+          <li key={link.href}>
+            <Link className="text-blue-600" href={link.href}>{link.label}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/dashboard/patients/page.tsx
+++ b/app/dashboard/patients/page.tsx
@@ -1,0 +1,4 @@
+import ModelManager from '@/components/ModelManager';
+export default function PatientsPage() {
+  return <ModelManager endpoint="/api/patients" fields={["name","email","phone"]} title="Patients" />;
+}

--- a/app/dashboard/studies/page.tsx
+++ b/app/dashboard/studies/page.tsx
@@ -1,0 +1,4 @@
+import ModelManager from '@/components/ModelManager';
+export default function StudiesPage() {
+  return <ModelManager endpoint="/api/studies" fields={["medicalReportId","studyTypeId","name"]} title="Studies" />;
+}

--- a/app/dashboard/study-types/page.tsx
+++ b/app/dashboard/study-types/page.tsx
@@ -1,0 +1,4 @@
+import ModelManager from '@/components/ModelManager';
+export default function StudyTypesPage() {
+  return <ModelManager endpoint="/api/study-types" fields={["categoryId","name","description"]} title="Study Types" />;
+}

--- a/app/infrastructure/database/index.ts
+++ b/app/infrastructure/database/index.ts
@@ -2,12 +2,16 @@ import { PrismaClient } from '@prisma/client';
 import { PatientRepository } from '../repositories/PatientRepository';
 import { MedicalReportRepository } from '../repositories/MedicalReportRepository';
 import { StudyTypeRepository } from '../repositories/StudyTypeRepository';
+import { CategoryRepository } from '../repositories/CategoryRepository';
+import { StudyRepository } from '../repositories/StudyRepository';
 
 export interface Database {
   prisma: PrismaClient;
   patientRepository: PatientRepository;
   medicalReportRepository: MedicalReportRepository;
   studyTypeRepository: StudyTypeRepository;
+  categoryRepository: CategoryRepository;
+  studyRepository: StudyRepository;
 }
 
 export function createDatabase(): Database {
@@ -21,5 +25,7 @@ export function createDatabase(): Database {
     patientRepository: new PatientRepository(prisma),
     medicalReportRepository: new MedicalReportRepository(prisma),
     studyTypeRepository: new StudyTypeRepository(prisma),
+    categoryRepository: new CategoryRepository(prisma),
+    studyRepository: new StudyRepository(prisma),
   };
 }

--- a/app/infrastructure/repositories/CategoryRepository.ts
+++ b/app/infrastructure/repositories/CategoryRepository.ts
@@ -1,0 +1,44 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+import { BaseRepository } from './BaseRepository';
+
+export class CategoryRepository extends BaseRepository<Prisma.CategoryDelegate> {
+  constructor(prisma: PrismaClient) {
+    super(prisma.category);
+  }
+
+  async getAllCategories() {
+    return this.model.findMany({
+      include: {
+        studyTypes: {
+          include: { category: true }
+        }
+      },
+      orderBy: { name: 'asc' }
+    });
+  }
+
+  async createCategory(data: Prisma.CategoryCreateInput) {
+    return this.model.create({
+      data: { ...data }
+    });
+  }
+
+  async getCategoryById(id: number) {
+    return this.model.findUnique({
+      where: { id }
+    });
+  }
+
+  async updateCategory(id: number, data: Prisma.CategoryUpdateInput) {
+    return this.model.update({
+      where: { id },
+      data
+    });
+  }
+
+  async deleteCategory(id: number) {
+    return this.model.delete({
+      where: { id }
+    });
+  }
+}

--- a/app/infrastructure/repositories/StudyRepository.ts
+++ b/app/infrastructure/repositories/StudyRepository.ts
@@ -1,0 +1,46 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+import { BaseRepository } from './BaseRepository';
+
+export class StudyRepository extends BaseRepository<Prisma.StudyDelegate> {
+  constructor(prisma: PrismaClient) {
+    super(prisma.study);
+  }
+
+  async getAllStudies() {
+    return this.model.findMany({
+      include: {
+        type: true,
+        medicalReport: true
+      }
+    });
+  }
+
+  async createStudy(data: Prisma.StudyCreateInput) {
+    return this.model.create({
+      data: { ...data, createdAt: new Date() }
+    });
+  }
+
+  async getStudyById(id: number) {
+    return this.model.findUnique({
+      where: { id },
+      include: {
+        type: true,
+        medicalReport: true
+      }
+    });
+  }
+
+  async updateStudy(id: number, data: Prisma.StudyUpdateInput) {
+    return this.model.update({
+      where: { id },
+      data
+    });
+  }
+
+  async deleteStudy(id: number) {
+    return this.model.delete({
+      where: { id }
+    });
+  }
+}

--- a/app/providers/APIProvider.ts
+++ b/app/providers/APIProvider.ts
@@ -60,6 +60,10 @@ export abstract class APIProvider {
     throw new Error('fetchStudyTypes must be implemented');
   }
 
+  async fetchStudies(): Promise<Study[]> {
+    throw new Error('fetchStudies must be implemented');
+  }
+
   async saveStudyType(_studyType: Partial<StudyType>): Promise<APIResponse<boolean>> {
     throw new Error('saveStudyType must be implemented');
   }

--- a/app/providers/DemoAPIProvider.ts
+++ b/app/providers/DemoAPIProvider.ts
@@ -274,6 +274,14 @@ export class DemoAPIProvider extends APIProvider {
     });
   }
 
+  async fetchStudies(): Promise<Study[]> {
+    return new Promise<Study[]>((resolve) => {
+      setTimeout(() => {
+        resolve(this.demoData.studies);
+      }, 300);
+    });
+  }
+
   async saveStudyType(studyType: Partial<StudyType>): Promise<APIResponse<boolean>> {
     return new Promise<APIResponse<boolean>>((resolve) => {
       setTimeout(() => {

--- a/app/providers/LiveAPIProvider.ts
+++ b/app/providers/LiveAPIProvider.ts
@@ -179,6 +179,21 @@ export class LiveAPIProvider extends APIProvider {
     }
   }
 
+  async fetchStudies(): Promise<Study[]> {
+    try {
+      const response = await fetch('/api/studies');
+      if (response.ok) {
+        return (await response.json()) as Study[];
+      }
+      throw new Error('Error fetching studies');
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new Error('Error fetching studies: ' + error.message);
+      }
+      throw error;
+    }
+  }
+
   async saveStudyType(studyType: Partial<StudyType>): Promise<APIResponse<boolean>> {
     try {
       const response = await fetch('/api/study-types', {

--- a/app/useCases/useCases.ts
+++ b/app/useCases/useCases.ts
@@ -118,6 +118,15 @@ export function useUseCases() {
     }
   };
 
+  const fetchStudies = async (): Promise<Study[]> => {
+    try {
+      return await apiProvider!.fetchStudies();
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+      throw new Error('Error fetching studies: ' + errorMessage);
+    }
+  };
+
   const saveStudy = async (study: Partial<Study>): Promise<APIResponse<boolean>> => {
     try {
       return await apiProvider!.saveStudy(study);
@@ -162,6 +171,7 @@ export function useUseCases() {
     saveCategory,
     fetchStudyTypes,
     saveStudyType,
+    fetchStudies,
     saveStudy,
     removeStudy,
     sendTokenByEmail,

--- a/components/ModelManager.tsx
+++ b/components/ModelManager.tsx
@@ -1,0 +1,81 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+interface Props {
+  endpoint: string;
+  fields: string[];
+  title: string;
+}
+
+export default function ModelManager({ endpoint, fields, title }: Props) {
+  const [items, setItems] = useState<any[]>([]);
+  const [form, setForm] = useState<Record<string, any>>({});
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const fetchItems = async () => {
+    const res = await fetch(endpoint);
+    const data = await res.json();
+    setItems(data);
+  };
+
+  useEffect(() => { fetchItems(); }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const saveItem = async () => {
+    await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...form, id: editingId || undefined })
+    });
+    setForm({});
+    setEditingId(null);
+    fetchItems();
+  };
+
+  const editItem = (item: any) => {
+    const f: Record<string, any> = {};
+    fields.forEach(fld => { f[fld] = item[fld] ?? ''; });
+    setForm(f);
+    setEditingId(item.id);
+  };
+
+  const deleteItem = async (id: number) => {
+    await fetch(`${endpoint}/${id}`, { method: 'DELETE' });
+    fetchItems();
+  };
+
+  return (
+    <div className="p-4 border rounded mb-6">
+      <h2 className="text-xl font-bold mb-2">{title}</h2>
+      <div className="flex flex-col gap-2 mb-4">
+        {fields.map(f => (
+          <input
+            key={f}
+            name={f}
+            placeholder={f}
+            className="border p-1"
+            value={form[f] || ''}
+            onChange={handleChange}
+          />
+        ))}
+        <button className="bg-blue-500 text-white px-2 py-1" onClick={saveItem}>
+          {editingId ? 'Update' : 'Create'}
+        </button>
+      </div>
+      <ul className="space-y-1">
+        {items.map(item => (
+          <li key={item.id} className="flex gap-2 items-center">
+            <span className="flex-1">
+              {fields.map(f => item[f]).join(' - ')}
+            </span>
+            <button className="text-sm text-blue-600" onClick={() => editItem(item)}>Edit</button>
+            <button className="text-sm text-red-600" onClick={() => deleteItem(item.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -11,6 +11,10 @@ export { useDebounce, useDebouncedCallback, useThrottledCallback } from './useDe
 export { useDemoHighlight } from './useDemoHighlight';
 export { useAppApi } from './useAppApi';
 export { usePatients } from './usePatients';
+export { useCategories } from './useCategories';
+export { useStudyTypes } from './useStudyTypes';
+export { useStudies } from './useStudies';
+export { useMedicalReports } from './useMedicalReports';
 
 // API hooks
 export {

--- a/hooks/useCategories.ts
+++ b/hooks/useCategories.ts
@@ -1,0 +1,7 @@
+import { useAppApi } from './useAppApi';
+import type { Category } from '@/types/providers';
+
+export function useCategories(immediate = true) {
+  const api = useAppApi<Category[]>('fetchCategories', [], { immediate });
+  return { ...api, categories: api.data ?? [] };
+}

--- a/hooks/useMedicalReports.ts
+++ b/hooks/useMedicalReports.ts
@@ -1,0 +1,7 @@
+import { useAppApi } from './useAppApi';
+import type { MedicalReport } from '@/types/providers';
+
+export function useMedicalReports(immediate = true) {
+  const api = useAppApi<MedicalReport[]>('fetchMedicalReports', [], { immediate });
+  return { ...api, medicalReports: api.data ?? [] };
+}

--- a/hooks/useStudies.ts
+++ b/hooks/useStudies.ts
@@ -1,0 +1,7 @@
+import { useAppApi } from './useAppApi';
+import type { Study } from '@/types/providers';
+
+export function useStudies(immediate = true) {
+  const api = useAppApi<Study[]>('fetchStudies', [], { immediate });
+  return { ...api, studies: api.data ?? [] };
+}

--- a/hooks/useStudyTypes.ts
+++ b/hooks/useStudyTypes.ts
@@ -1,0 +1,7 @@
+import { useAppApi } from './useAppApi';
+import type { StudyType } from '@/types/providers';
+
+export function useStudyTypes(immediate = true) {
+  const api = useAppApi<StudyType[]>('fetchStudyTypes', [], { immediate });
+  return { ...api, studyTypes: api.data ?? [] };
+}


### PR DESCRIPTION
## Summary
- add repositories for Category and Study models
- extend database factory
- implement API routes for all prisma models
- add generic ModelManager component
- create dashboard pages for CRUD operations
- expose new hooks and API provider methods

## Testing
- `npm test` *(fails: Cannot find module '@auth0/nextjs-auth0/client')*
- `npm run type-check`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686b74025ae08333be5ab08769642206