### PR TITLE
Fix localization in tests

### DIFF
--- a/__tests__/HomePage.test.jsx
+++ b/__tests__/HomePage.test.jsx
@@ -21,7 +21,7 @@ describe('HomePage', () => {
         </I18nProvider>
       </ThemeProvider>
     )
-    expect(await screen.findByText(/Convierte consultas médicas/i)).toBeInTheDocument()
+    expect(await screen.findByText(/Herramientas inteligentes/i)).toBeInTheDocument()
   })
 
   it('contains the main SYMFARMIA branding', async () => {
@@ -37,7 +37,7 @@ describe('HomePage', () => {
       </ThemeProvider>
     )
     const heading = await screen.findByRole('heading', { level: 1 })
-    expect(heading).toHaveTextContent('Convierte consultas médicas en reportes clínicos automáticamente')
+    expect(heading).toHaveTextContent('Herramientas inteligentes para médicos modernos')
   })
 
   it('displays the platform description', () => {
@@ -52,6 +52,6 @@ describe('HomePage', () => {
         </I18nProvider>
       </ThemeProvider>
     )
-    expect(screen.getByText(/Habla durante tu consulta/i)).toBeInTheDocument()
+    expect(screen.getByText(/Ahorra tiempo de papeleo/i)).toBeInTheDocument()
   })
 })

--- a/__tests__/LandingPage.test.jsx
+++ b/__tests__/LandingPage.test.jsx
@@ -37,7 +37,7 @@ describe('LandingPage', () => {
         </I18nProvider>
       </ThemeProvider>
     )
-    expect(screen.getByText('Plataforma inteligente para médicos independientes')).toBeInTheDocument()
+    expect(screen.getByText('Administra expedientes, reportes y analíticas desde un solo lugar')).toBeInTheDocument()
   })
 
   it('renders Login and Register buttons', () => {
@@ -79,7 +79,7 @@ describe('LandingPage', () => {
     )
     const demoButton = screen.getByRole('button', { name: /probar modo demo/i })
     fireEvent.click(demoButton)
-    expect(screen.getByText('Acceso Demo')).toBeInTheDocument()
+    expect(screen.getByText('Acceso al Demo')).toBeInTheDocument()
   })
 
   it('renders feature cards', () => {
@@ -92,9 +92,9 @@ describe('LandingPage', () => {
         </I18nProvider>
       </ThemeProvider>
     )
-    expect(screen.getByText('Patient Management')).toBeInTheDocument()
-    expect(screen.getByText('Medical Reports')).toBeInTheDocument()
-    expect(screen.getByText('Analytics')).toBeInTheDocument()
+    expect(screen.getByText('Gestión de Pacientes')).toBeInTheDocument()
+    expect(screen.getByText('Reportes Médicos')).toBeInTheDocument()
+    expect(screen.getByText('Analíticas')).toBeInTheDocument()
   })
 
   it('has correct Login link href', () => {

--- a/__tests__/Layout.test.jsx
+++ b/__tests__/Layout.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import RootLayout from '../app/layout'
+import { SITE_CONFIG } from '../app/lib/site-config'
 
 describe('RootLayout', () => {
   const mockChildren = <div>Test Children Content</div>
@@ -11,8 +12,8 @@ describe('RootLayout', () => {
 
   it('has correct metadata structure', () => {
     const { metadata } = require('../app/layout')
-    expect(metadata.title).toBe('SYMFARMIA - Plataforma inteligente para médicos independientes')
-    expect(metadata.description).toBe('Convierte consultas médicas en reportes clínicos automáticamente. Habla durante tu consulta y obtén un reporte médico estructurado en segundos.')
+    expect(metadata.title).toBe(SITE_CONFIG.title)
+    expect(metadata.description).toBe(SITE_CONFIG.description)
   })
 
   it('renders with proper HTML structure', () => {

--- a/app/providers/I18nProvider.js
+++ b/app/providers/I18nProvider.js
@@ -57,6 +57,17 @@ const fallbackTranslations = {
     'spanish': 'Español',
     'english_abbr': 'EN',
     'spanish_abbr': 'ES'
+    , 'hero_heading': 'Herramientas inteligentes para médicos modernos'
+    , 'hero_subheading': 'Ahorra tiempo de papeleo y enfócate en tus pacientes'
+    , 'tagline': 'Administra expedientes, reportes y analíticas desde un solo lugar'
+    , 'login': 'Iniciar sesión'
+    , 'register': 'Registrarse'
+    , 'try_demo': 'Probar modo demo'
+    , 'patient_management': 'Gestión de Pacientes'
+    , 'medical_reports': 'Reportes Médicos'
+    , 'analytics': 'Analíticas'
+    , 'welcome_to': 'Bienvenido a'
+    , 'demo_login': 'Acceso al Demo'
   },
   'en': {
     'transcription.title': 'Real-time Transcription',
@@ -78,6 +89,17 @@ const fallbackTranslations = {
     'spanish': 'Spanish',
     'english_abbr': 'EN',
     'spanish_abbr': 'ES'
+    , 'hero_heading': 'Intelligent tools for modern doctors'
+    , 'hero_subheading': 'Save paperwork time and focus on your patients'
+    , 'tagline': 'Manage records, reports and analytics in one place'
+    , 'login': 'Login'
+    , 'register': 'Register'
+    , 'try_demo': 'Try demo mode'
+    , 'patient_management': 'Patient Management'
+    , 'medical_reports': 'Medical Reports'
+    , 'analytics': 'Analytics'
+    , 'welcome_to': 'Welcome to'
+    , 'demo_login': 'Access Demo'
   }
 };
 


### PR DESCRIPTION
## Summary
- update metadata test to use site config
- align HomePage and LandingPage tests with new Spanish copy
- provide essential fallback translations for I18nProvider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686b7d0db030833384f39b5b5ab5418c