### PR TITLE
Lazy load legacy route

### DIFF
--- a/app/legacy/page.js
+++ b/app/legacy/page.js
@@ -1,6 +1,11 @@
 "use client"
 import { withPageAuthRequired } from '@auth0/nextjs-auth0';
-import LegacyApp from '../../legacy_core/app/app.js';
+import dynamic from 'next/dynamic';
+
+const LegacyApp = dynamic(() => import('../../legacy_core/app/app.js'), {
+  ssr: false,
+  loading: () => <p>Loading legacy module...</p>,
+});
 
 export const dynamic = "force-dynamic";
 


### PR DESCRIPTION
## Summary
- use Next.js dynamic import for the legacy route to shrink bundle size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686b8dcb7a808333a8d9fc67892b6062