### PR TITLE
Implement real audio capture and medical demo API

### DIFF
--- a/app/api/medical-ai/demo/route.js
+++ b/app/api/medical-ai/demo/route.js
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { processMedicalQuery, getErrorMessage } from '@/app/services/MedicalAILogic.js';
+import { MedicalAIConfig } from '@/app/config/MedicalAIConfig.js';
+
+const dependencies = {
+  config: MedicalAIConfig,
+  httpClient: {
+    fetch: (...args) => globalThis.fetch(...args)
+  }
+};
+
+const MEDICAL_KEYWORDS = [
+  'duele',
+  'dolor',
+  'enfermo',
+  'síntoma',
+  'fiebre',
+  'cabeza',
+  'estómago',
+  'tos',
+  'mareo',
+  'náusea'
+];
+
+function generateContextualResponse(text) {
+  if (/^hola\b/i.test(text.trim())) {
+    return 'Hola, soy tu asistente médico. ¿En qué puedo ayudarte hoy?';
+  }
+  return 'Cuéntame más sobre tu consulta médica.';
+}
+
+export async function POST(request) {
+  try {
+    const { input } = await request.json();
+    if (!input) {
+      return NextResponse.json({ error: 'Input is required' }, { status: 400 });
+    }
+
+    const isMedical = MEDICAL_KEYWORDS.some(k => input.toLowerCase().includes(k));
+
+    if (isMedical) {
+      const result = await processMedicalQuery({ query: input, type: 'diagnosis' }, dependencies);
+      return NextResponse.json({ success: true, ...result });
+    }
+
+    const response = generateContextualResponse(input);
+    return NextResponse.json({ success: true, response });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: getErrorMessage(error.status) || 'Internal server error',
+        details: error.message,
+        status: error.status || 500
+      },
+      { status: error.status || 500 }
+    );
+  }
+}
+
+export async function GET() {
+  return NextResponse.json({
+    message: 'Medical AI Demo endpoint',
+    usage: 'POST { input: string }',
+    success: true
+  });
+}

--- a/hooks/useRealAudioCapture.ts
+++ b/hooks/useRealAudioCapture.ts
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+
+export const useRealAudioCapture = () => {
+  const [isRecording, setIsRecording] = useState(false);
+  const [transcript, setTranscript] = useState('');
+  const [audioStream, setAudioStream] = useState<MediaStream | null>(null);
+
+  const enableTextInputMode = () => {
+    setIsRecording(false);
+    setTranscript('');
+    if (audioStream) {
+      audioStream.getTracks().forEach(t => t.stop());
+    }
+  };
+
+  const startRealTimeTranscription = (stream: MediaStream) => {
+    const SpeechRecognition =
+      (window as any).webkitSpeechRecognition || (window as any).SpeechRecognition;
+    if (!SpeechRecognition) {
+      console.warn('Speech recognition not supported');
+      return;
+    }
+    const recognition = new SpeechRecognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = 'es-MX';
+    recognition.onresult = event => {
+      const text = Array.from(event.results)
+        .map((r: any) => r[0].transcript)
+        .join('');
+      setTranscript(text);
+    };
+    recognition.start();
+  };
+
+  const startRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          sampleRate: 16000,
+        },
+      });
+      setAudioStream(stream);
+      setIsRecording(true);
+      startRealTimeTranscription(stream);
+    } catch (error) {
+      console.error('Audio access denied:', error);
+      enableTextInputMode();
+    }
+  };
+
+  const stopRecording = () => {
+    setIsRecording(false);
+    if (audioStream) {
+      audioStream.getTracks().forEach(t => t.stop());
+    }
+  };
+
+  return {
+    isRecording,
+    transcript,
+    startRecording,
+    stopRecording,
+  };
+};

--- a/tests/api/medicalAiDemo.test.js
+++ b/tests/api/medicalAiDemo.test.js
@@ -1,0 +1,69 @@
+import { POST, GET } from '../../app/api/medical-ai/demo/route.js';
+import { MedicalAIConfig } from '../../app/config/MedicalAIConfig.js';
+
+function createRequest(body, method = 'POST') {
+  return {
+    json: async () => body,
+    method,
+    headers: { get: () => 'application/json' }
+  };
+}
+
+global.fetch = jest.fn();
+
+const originalEnv = process.env;
+
+describe('/api/medical-ai/demo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('POST', () => {
+    it('should return 400 when input is missing', async () => {
+      const response = await POST(createRequest({}));
+      const data = await response.json();
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('Input is required');
+    });
+
+    it('should return greeting for non medical input', async () => {
+      const response = await POST(createRequest({ input: 'Hola' }));
+      const data = await response.json();
+      expect(response.status).toBe(200);
+      expect(data.response).toContain('Hola');
+    });
+
+    it('should call medical query for medical input', async () => {
+      process.env.HUGGINGFACE_TOKEN = 'token';
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({ generated_text: 'Test' })
+      };
+      global.fetch.mockResolvedValue(mockResponse);
+
+      const response = await POST(createRequest({ input: 'Me duele la cabeza' }));
+      const data = await response.json();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `https://api-inference.huggingface.co/models/${MedicalAIConfig.getModel('diagnosis')}`,
+        expect.any(Object)
+      );
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+    });
+  });
+
+  describe('GET', () => {
+    it('should return endpoint info', async () => {
+      const response = await GET(createRequest(null, 'GET'));
+      const data = await response.json();
+      expect(response.status).toBe(200);
+      expect(data.message).toBe('Medical AI Demo endpoint');
+    });
+  });
+});

--- a/utils/processmedicalInput.ts
+++ b/utils/processmedicalInput.ts
@@ -1,0 +1,42 @@
+import { processMedicalQuery } from '@/app/services/MedicalAILogic.js';
+import { MedicalAIConfig } from '@/app/config/MedicalAIConfig.js';
+
+const MEDICAL_KEYWORDS = [
+  'duele',
+  'dolor',
+  'enfermo',
+  'síntoma',
+  'fiebre',
+  'cabeza',
+  'estómago',
+  'tos',
+  'mareo',
+  'náusea'
+];
+
+function generateContextualResponse(text: string) {
+  if (/hola/i.test(text)) {
+    return 'Hola, soy tu asistente médico. ¿En qué puedo ayudarte hoy?';
+  }
+  return 'Cuéntame más sobre tu consulta médica.';
+}
+
+export const processmedicalInput = async (userInput: string) => {
+  const isMedicalQuery = MEDICAL_KEYWORDS.some(keyword =>
+    userInput.toLowerCase().includes(keyword)
+  );
+
+  if (isMedicalQuery) {
+    const dependencies = {
+      config: MedicalAIConfig,
+      httpClient: { fetch: (...args: any[]) => globalThis.fetch(...args) }
+    };
+    const medicalResponse = await processMedicalQuery(
+      { query: userInput, type: 'diagnosis' },
+      dependencies
+    );
+    return medicalResponse;
+  }
+
+  return { response: generateContextualResponse(userInput) };
+};


### PR DESCRIPTION
## Summary
- add medical AI demo endpoint for contextual responses
- add hook `useRealAudioCapture` for capturing audio
- add keyword-based medical input processor
- test medical AI demo endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686b8f85568c8333a9f7e657a360a583