### PR TITLE
Fix type errors in processmedicalInput

### DIFF
--- a/utils/processmedicalInput.ts
+++ b/utils/processmedicalInput.ts
@@ -29,10 +29,12 @@ export const processmedicalInput = async (userInput: string) => {
   if (isMedicalQuery) {
     const dependencies = {
       config: MedicalAIConfig,
-      httpClient: { fetch: (...args: any[]) => globalThis.fetch(...args) }
+      httpClient: {
+        fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args)
+      }
     };
     const medicalResponse = await processMedicalQuery(
-      { query: userInput, type: 'diagnosis' },
+      { query: userInput, context: {}, type: 'diagnosis' },
       dependencies
     );
     return medicalResponse;


### PR DESCRIPTION
## Summary
- fix typings when delegating to processMedicalQuery

## Testing
- `npm run type-check`
- `npm run build` *(fails: Identifier 'dynamic' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_b_686b95bd7778833380c0a85e9b2327be