### PR TITLE
Fix lint warnings

### DIFF
--- a/src/components/consultation/settings/AISettings.jsx
+++ b/src/components/consultation/settings/AISettings.jsx
@@ -3,7 +3,6 @@ import { motion } from 'framer-motion';
 import {
   SparklesIcon,
   HeartIcon,
-  UserGroupIcon,
   ExclamationTriangleIcon,
   DocumentTextIcon,
   ShieldExclamationIcon

--- a/src/components/consultation/settings/AudioSettings.jsx
+++ b/src/components/consultation/settings/AudioSettings.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import {
   MicrophoneIcon,
-  SpeakerWaveIcon,
   SignalIcon,
   ShieldCheckIcon,
   AdjustmentsHorizontalIcon

--- a/src/components/consultation/settings/TranscriptionSettings.jsx
+++ b/src/components/consultation/settings/TranscriptionSettings.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import {
-  DocumentTextIcon,
   GlobeAltIcon,
   ChartBarIcon,
   BoltIcon,


### PR DESCRIPTION
## Summary
- remove unused icon imports from consultation settings

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686b9fe79630833384e0d83e4e681518