### PR TITLE
Add translation validation script and tests

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -203,5 +203,11 @@
   "guadalajara_to_world": "From Guadalajara to the world - transforming medicine",
   "future_is_bright": "The future is bright, the future is now",
   "transformation_within_reach": "The transformation of Mexican medicine is within reach",
-  "join_renaissance": "Join the Renaissance"
+  "join_renaissance": "Join the Renaissance",
+  "conversation.capture.title": "Conversation Capture",
+  "conversation.capture.subtitle": "Record and transcribe medical consultations",
+  "conversation.capture.start": "Start Recording",
+  "conversation.capture.stop": "Stop Recording",
+  "medical.transcription.start": "Start Medical Transcription",
+  "medical.transcription.stop": "Stop Medical Transcription"
 }

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -203,5 +203,11 @@
   "guadalajara_to_world": "Desde Guadalajara hasta el mundo - transformamos la medicina",
   "future_is_bright": "El futuro es brillante, el futuro es ahora",
   "transformation_within_reach": "La transformación de la medicina mexicana está a nuestro alcance",
-  "join_renaissance": "Únete al Renacimiento"
+  "join_renaissance": "Únete al Renacimiento",
+  "conversation.capture.title": "Captura de Conversación",
+  "conversation.capture.subtitle": "Graba y transcribe consultas médicas",
+  "conversation.capture.start": "Iniciar Grabación",
+  "conversation.capture.stop": "Detener Grabación",
+  "medical.transcription.start": "Iniciar Transcripción Médica",
+  "medical.transcription.stop": "Detener Transcripción Médica"
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "predev": "node scripts/validate-turbo.js",
+    "prebuild": "npm run validate:translations",
+    "predev": "npm run validate:translations && node scripts/validate-turbo.js",
+    "validate:translations": "node scripts/validate-translations.js",
+    "test:translations": "jest tests/medical-components/translations.test.js",
     "dev": "NODE_OPTIONS='--max-old-space-size=4096 --no-warnings' next dev --turbo",
     "validate-turbo": "node scripts/validate-turbo.js",
     "build": "npm run test:transcription-components && node scripts/build-monitor.js build",

--- a/scripts/validate-translations.js
+++ b/scripts/validate-translations.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+
+const getAllJSXFiles = (dir) => {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  let files = [];
+  entries.forEach((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files = files.concat(getAllJSXFiles(fullPath));
+    } else if (/\.(js|jsx|ts|tsx)$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  });
+  return files;
+};
+
+const extractTranslationKeys = (directory) => {
+  const files = getAllJSXFiles(directory);
+  const keys = new Set();
+  files.forEach((file) => {
+    const content = fs.readFileSync(file, 'utf8');
+    const matches = content.match(/\bt\(['"`]([^'"`]+)['"`]\)/g);
+    if (matches) {
+      matches.forEach((match) => {
+        const key = match.match(/['"`]([^'"`]+)['"`]/)[1];
+        keys.add(key);
+      });
+    }
+  });
+  return Array.from(keys);
+};
+
+const addMissingTranslations = (missingKeys) => {
+  missingKeys.forEach(({ key, locale }) => {
+    const filePath = path.join(__dirname, `../locales/${locale}/common.json`);
+    const translations = require(filePath);
+    translations[key] = `TODO_TRANSLATE_${key.toUpperCase()}`;
+    fs.writeFileSync(filePath, JSON.stringify(translations, null, 2));
+    console.log(`➕ Added placeholder for ${locale}:${key}`);
+  });
+};
+
+const generateTranslationTests = (keys) => {
+  const esTranslations = require(path.join(__dirname, '../locales/es/common.json'));
+  const enTranslations = require(path.join(__dirname, '../locales/en/common.json'));
+  const testCases = keys
+    .map((key) => {
+      return `test('${key} translation exists', () => {\n  expect(esTranslations['${key}']).toBeDefined();\n  expect(enTranslations['${key}']).toBeDefined();\n  expect(esTranslations['${key}']).not.toMatch(/TODO_TRANSLATE/);\n});`;
+    })
+    .join('\n');
+  const content = `const esTranslations = require('../locales/es/common.json');\nconst enTranslations = require('../locales/en/common.json');\n\ndescribe('Auto Generated Translation Tests', () => {\n${testCases}\n});\n`;
+  fs.writeFileSync('./tests/auto-generated-translation.test.js', content);
+};
+
+const validateTranslations = () => {
+  const esTranslations = require(path.join(__dirname, '../locales/es/common.json'));
+  const enTranslations = require(path.join(__dirname, '../locales/en/common.json'));
+  const usedKeys = extractTranslationKeys('./src');
+  const missingKeys = [];
+
+  usedKeys.forEach((key) => {
+    if (!esTranslations[key]) {
+      missingKeys.push({ key, locale: 'es' });
+    }
+    if (!enTranslations[key]) {
+      missingKeys.push({ key, locale: 'en' });
+    }
+  });
+
+  generateTranslationTests(usedKeys);
+
+  if (missingKeys.length > 0) {
+    console.error('❌ MISSING TRANSLATION KEYS:');
+    missingKeys.forEach(({ key, locale }) => {
+      console.error(`  ${locale}: "${key}"`);
+    });
+    addMissingTranslations(missingKeys);
+    process.exit(1);
+  }
+
+  console.log('✅ All translation keys validated');
+};
+
+if (require.main === module) {
+  validateTranslations();
+}
+
+module.exports = { validateTranslations, extractTranslationKeys };

--- a/tests/medical-components/translations.test.js
+++ b/tests/medical-components/translations.test.js
@@ -1,0 +1,27 @@
+describe('Translation Coverage', () => {
+  test('conversation.capture.title must exist', () => {
+    const esCommon = require('../../locales/es/common.json');
+    const enCommon = require('../../locales/en/common.json');
+
+    expect(esCommon['conversation.capture.title']).toBeDefined();
+    expect(enCommon['conversation.capture.title']).toBeDefined();
+    expect(esCommon['conversation.capture.title']).not.toMatch(/TODO_TRANSLATE/);
+  });
+
+  test('all medical components have translations', () => {
+    const esTranslations = require('../../locales/es/common.json');
+    const enTranslations = require('../../locales/en/common.json');
+
+    const medicalKeys = [
+      'conversation.capture.title',
+      'conversation.capture.subtitle',
+      'medical.transcription.start',
+      'medical.transcription.stop'
+    ];
+
+    medicalKeys.forEach(key => {
+      expect(esTranslations[key]).toBeDefined();
+      expect(enTranslations[key]).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add missing translation keys for conversation capture and medical transcription
- add translation validation script with test generation
- run translation tests as part of CI scripts
- add initial translation coverage test

## Testing
- `npm run test:translations`
- `npm test` *(fails: SyntaxError in diagnostic.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_686e22afa45883338ce1a30383dee7de