### PR TITLE
Add placeholder translation keys

### DIFF
--- a/locales/en/microphone.json
+++ b/locales/en/microphone.json
@@ -1,0 +1,17 @@
+{
+  "microphone": {
+    "status": {
+      "problem_with_microphone": "Call administrator to fill this value",
+      "problems_detected": "Call administrator to fill this value",
+      "recommended_solutions": "Call administrator to fill this value",
+      "detected_devices": "Call administrator to fill this value",
+      "technical_details": "Call administrator to fill this value",
+      "need_access": "Call administrator to fill this value"
+    },
+    "actions": {
+      "diagnose": "Call administrator to fill this value",
+      "retry": "Call administrator to fill this value",
+      "test_access": "Call administrator to fill this value"
+    }
+  }
+}

--- a/locales/en/transcription.json
+++ b/locales/en/transcription.json
@@ -4,6 +4,18 @@
     "ready_to_record": "Ready to Record",
     "start_recording": "Start Recording",
     "stop_recording": "Stop Recording",
-    "no_transcript_available": "No transcript available"
+    "no_transcript_available": "No transcript available",
+    "reset_demo": "Call administrator to fill this value",
+    "final_transcript": "Call administrator to fill this value",
+    "service_label": "Call administrator to fill this value",
+    "medical_ai_active": "Call administrator to fill this value",
+    "words_count": "Call administrator to fill this value",
+    "recording": "Call administrator to fill this value",
+    "transcribing": "Call administrator to fill this value",
+    "demo_empty_state": "Call administrator to fill this value",
+    "no_transcript_description": "Call administrator to fill this value",
+    "service_browser": "Call administrator to fill this value",
+    "service_whisper": "Call administrator to fill this value",
+    "ai_active": "Call administrator to fill this value"
   }
 }

--- a/locales/es/microphone.json
+++ b/locales/es/microphone.json
@@ -1,0 +1,17 @@
+{
+  "microphone": {
+    "status": {
+      "problem_with_microphone": "Llamar al administrador para llenar este valor",
+      "problems_detected": "Llamar al administrador para llenar este valor",
+      "recommended_solutions": "Llamar al administrador para llenar este valor",
+      "detected_devices": "Llamar al administrador para llenar este valor",
+      "technical_details": "Llamar al administrador para llenar este valor",
+      "need_access": "Llamar al administrador para llenar este valor"
+    },
+    "actions": {
+      "diagnose": "Llamar al administrador para llenar este valor",
+      "retry": "Llamar al administrador para llenar este valor",
+      "test_access": "Llamar al administrador para llenar este valor"
+    }
+  }
+}

--- a/locales/es/transcription.json
+++ b/locales/es/transcription.json
@@ -4,6 +4,18 @@
     "ready_to_record": "Listo para Grabar",
     "start_recording": "Iniciar Grabación",
     "stop_recording": "Detener Grabación",
-    "no_transcript_available": "No hay transcripción disponible"
+    "no_transcript_available": "No hay transcripción disponible",
+    "reset_demo": "Llamar al administrador para llenar este valor",
+    "final_transcript": "Llamar al administrador para llenar este valor",
+    "service_label": "Llamar al administrador para llenar este valor",
+    "medical_ai_active": "Llamar al administrador para llenar este valor",
+    "words_count": "Llamar al administrador para llenar este valor",
+    "recording": "Llamar al administrador para llenar este valor",
+    "transcribing": "Llamar al administrador para llenar este valor",
+    "demo_empty_state": "Llamar al administrador para llenar este valor",
+    "no_transcript_description": "Llamar al administrador para llenar este valor",
+    "service_browser": "Llamar al administrador para llenar este valor",
+    "service_whisper": "Llamar al administrador para llenar este valor",
+    "ai_active": "Llamar al administrador para llenar este valor"
   }
 }


### PR DESCRIPTION
## Summary
- add missing transcription keys to English and Spanish locales
- create microphone translation files with placeholder values
- ensure translation validation passes

## Testing
- `npm run translations:validate-strict`

------
https://chatgpt.com/codex/tasks/task_b_6870270bddb083339253b1e3a35e0e53