### PR TITLE
Fix service worker registration

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -363,15 +363,7 @@ export default function RootLayout({ children }) {
         />
         <script
           dangerouslySetInnerHTML={{
-            __html: `
-              if ('serviceWorker' in navigator) {
-                window.addEventListener('load', function () {
-                  navigator.serviceWorker.register('/sw.js').catch(function (err) {
-                    console.error('Service worker registration failed:', err);
-                  });
-                });
-              }
-            `,
+            __html: require("../utils/pwa/ServiceWorkerManager").getRegisterScript()
           }}
         />
       </body>

--- a/components/BraveCacheBuster.tsx
+++ b/components/BraveCacheBuster.tsx
@@ -45,11 +45,7 @@ export default function BraveCacheBuster() {
     
     detectBrave().then(isBraveDetected => {
       if (isBraveDetected && process.env.NODE_ENV === 'development') {
-        logWarn('BRAVE BROWSER DETECTED - INITIATING NUCLEAR CACHE DESTRUCTION')
-        
-        // Nuclear cache destruction
-        destroyAllCaches()
-        
+        logWarn('BRAVE BROWSER DETECTED - cache bust tools enabled')
         // Show instructions after a delay
         setTimeout(() => setShowInstructions(true), 2000)
       }

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,11 @@
 let withPWA = (config) => config;
 try {
   const pwa = require('next-pwa');
-  withPWA = pwa({ dest: 'public', disable: process.env.NODE_ENV === 'development' });
+  withPWA = pwa({
+    dest: 'public',
+    disable: process.env.NODE_ENV === 'development',
+    buildExcludes: [/app-build-manifest\.json$/]
+  });
 } catch (err) {
   console.warn('next-pwa not available, skipping PWA setup');
 }

--- a/utils/pwa/ServiceWorkerManager.js
+++ b/utils/pwa/ServiceWorkerManager.js
@@ -1,0 +1,10 @@
+export function getRegisterScript() {
+  if (process.env.NODE_ENV !== 'production') return '';
+  return `if ('serviceWorker' in navigator) {
+    window.addEventListener('load', function () {
+      navigator.serviceWorker.register('/sw.js').catch(function (err) {
+        console.error('Service worker registration failed:', err);
+      });
+    });
+  }`;
+}


### PR DESCRIPTION
## Summary
- filter development manifests from next-pwa precache
- add ServiceWorkerManager for environment-aware registration
- avoid automatic cache nuking in BraveCacheBuster
- use ServiceWorkerManager in layout

## Testing
- `npm run lint` *(fails: numerous eslint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68707c8c40208333bf32dcd9b4d465c7