### PR TITLE
Fix FOUC and preload i18n translations

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -15,7 +15,7 @@ import { ThemeProvider } from "./providers/ThemeProviderBulletproof";
 import { Auth0Provider } from "@auth0/nextjs-auth0";
 import { AppModeProvider } from "./providers/AppModeProvider";
 import DemoModeBanner from "./components/DemoModeBanner";
-import { I18nProvider } from "./providers/I18nProvider";
+import I18nServerProvider from "./providers/I18nServerProvider";
 import { PatientContextProvider } from "./providers/PatientContextProvider";
 import MedicalAssistant from "./components/MedicalAssistantWrapper";
 import VersionInfo from "./components/VersionInfo";
@@ -251,7 +251,7 @@ export default function RootLayout({ children }) {
                   
                   {/* PROVIDERS ERROR BOUNDARY */}
                   <MedicalErrorBoundary context="Providers" medicalWorkflow="App Context">
-                    <I18nProvider>
+                    <I18nServerProvider>
                       <PatientContextProvider>
                         <AppModeProvider>
                           
@@ -294,7 +294,7 @@ export default function RootLayout({ children }) {
                           
                         </AppModeProvider>
                       </PatientContextProvider>
-                    </I18nProvider>
+                    </I18nServerProvider>
                   </MedicalErrorBoundary>
                   
                 </Auth0Provider>

--- a/app/providers/I18nProvider.js
+++ b/app/providers/I18nProvider.js
@@ -98,11 +98,11 @@ function detectUserLanguage() {
   return 'es'; // Default to Spanish
 }
 
-export function I18nProvider({ children }) {
-  const [locale, setLocale] = useState('es'); // Always start with 'es' for consistent SSR
+export function I18nProvider({ children, initialLocale = 'es', initialTranslations = {} }) {
+  const [locale, setLocale] = useState(initialLocale);
   const [hasHydrated, setHasHydrated] = useState(false);
-  const [translations, setTranslations] = useState({});
-  const [isLoadingTranslations, setIsLoadingTranslations] = useState(true);
+  const [translations, setTranslations] = useState(initialTranslations);
+  const [isLoadingTranslations, setIsLoadingTranslations] = useState(Object.keys(initialTranslations).length === 0);
   const [loadError, setLoadError] = useState(null);
   const [retryCount, setRetryCount] = useState(0);
   const loadingRef = useRef(false);
@@ -160,8 +160,10 @@ export function I18nProvider({ children }) {
 
   // Load translations when locale changes
   useEffect(() => {
-    loadAndSetTranslations(locale);
-  }, [locale, loadAndSetTranslations]);
+    if (Object.keys(translations).length === 0 || locale !== initialLocale) {
+      loadAndSetTranslations(locale);
+    }
+  }, [locale, loadAndSetTranslations, translations, initialLocale]);
 
   useEffect(() => {
     // Only run once on client side - detect and set user language after hydration

--- a/app/providers/I18nServerProvider.js
+++ b/app/providers/I18nServerProvider.js
@@ -1,0 +1,59 @@
+import I18nProvider from "./I18nProvider";
+
+const translationFiles = [
+  "common",
+  "clinical",
+  "orders",
+  "navigation",
+  "conversation",
+  "status",
+  "landing",
+  "dashboard",
+  "workflow",
+  "demo",
+  "dialogue",
+  "transcription",
+  "language_switcher",
+  "ui",
+  "errors",
+];
+
+function flattenObject(obj, prefix = "") {
+  return Object.keys(obj).reduce((acc, key) => {
+    const newKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof obj[key] === "object" && obj[key] !== null) {
+      Object.assign(acc, flattenObject(obj[key], newKey));
+    } else {
+      acc[newKey] = obj[key];
+    }
+    return acc;
+  }, {});
+}
+
+async function loadServerTranslations(locale) {
+  const modules = await Promise.all(
+    translationFiles.map((file) =>
+      import(`../../locales/${locale}/${file}.json`)
+    )
+  );
+  const translations = {};
+  modules.forEach((mod) => {
+    Object.assign(translations, flattenObject(mod.default || mod));
+  });
+  return translations;
+}
+
+export default async function I18nServerProvider({ children }) {
+  const locale = "es";
+  let translations = {};
+  try {
+    translations = await loadServerTranslations(locale);
+  } catch (e) {
+    console.error("Failed to preload translations", e);
+  }
+  return (
+    <I18nProvider initialLocale={locale} initialTranslations={translations}>
+      {children}
+    </I18nProvider>
+  );
+}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -119,5 +119,9 @@
   },
   "reset": "Reset",
   "copy": "Copy",
-  "next": "Next"
+  "next": "Next",
+  "conversation.capture.title": "Conversation Capture",
+  "conversation.capture.subtitle": "Press record to start medical transcription",
+  "medical.transcription.start": "Start Recording",
+  "medical.transcription.stop": "Stop Recording"
 }

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -119,5 +119,9 @@
   },
   "reset": "Reiniciar",
   "copy": "Copiar",
-  "next": "Siguiente"
+  "next": "Siguiente",
+  "conversation.capture.title": "Captura de Conversación",
+  "conversation.capture.subtitle": "Presiona grabar para comenzar la transcripción médica",
+  "medical.transcription.start": "Iniciar Grabación",
+  "medical.transcription.stop": "Detener Grabación"
 }

--- a/next.config.js
+++ b/next.config.js
@@ -27,10 +27,6 @@ const nextConfig = {
       path: false,
       crypto: false,
     };
-     config.module.rules.push({
-      test: /\.css$/,
-      use: ['style-loader', 'css-loader', 'postcss-loader'],
-    });
     return config;
   },
 


### PR DESCRIPTION
## Summary
- remove custom style-loader rule that caused FOUC
- allow `I18nProvider` to accept initial translations
- add server wrapper to preload translations on SSR
- use new provider in root layout
- add missing conversation keys in translations

## Testing
- `node scripts/validate-translations.js`
- `npm test` *(fails: jest configuration errors)*

------
https://chatgpt.com/codex/tasks/task_b_687452a60be883338f51de2d70bbdd6e