### PR TITLE
Add humor to AGENTS docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# SYMFARMIA AGENTS Overview
+
+This file defines the basic instructions for AI assistants working in this repository.
+For the full multi-agent workflow specification, see [docs/workflows/Agents.md](docs/workflows/Agents.md).
+Feel free to sprinkle a tasteful joke here and there—future readers will appreciate the chuckle.
+
+## Required Checks
+
+Before committing any code changes, run:
+
+```bash
+npm run lint
+npm test
+```
+
+Treat warnings as errors and ensure tests pass. If commands fail due to a missing
+package or environment issue, document it in your PR testing section.
+
+## Commit Messages
+
+- Use concise messages describing the change.
+- Reference affected files or features when possible.
+
+## Documentation Philosophy
+
+Documentation lives under the `docs` folder. Each topic has its own subfolder.
+Contributors should keep documentation synchronized with code changes and consult
+`docs/README.md` for the full structure.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ Welcome to the SYMFARMIA documentation hub. This directory contains all project 
 
 ### 🔄 [Workflows](./workflows/)
 - [**Agents**](./workflows/Agents.md) - Multi-agent workflow documentation
+- [**Root AGENTS Guide**](../AGENTS.md) - Quick instructions for all AI assistants (and a reminder to keep the docs fun)
 
 ### 📝 [Changelog](./changelog/)
 - [**CHANGELOG**](./changelog/CHANGELOG.md) - Version history and updates

--- a/docs/workflows/Agents.md
+++ b/docs/workflows/Agents.md
@@ -1,6 +1,7 @@
 # SYMFARMIA Agents.md Guide v3 - Multi-Agent Medical Development
 
-This Agents.md file provides comprehensive guidance for **Claudio**, **Codex**, and other AI agents working with the SYMFARMIA medical platform codebase following official Agents.md standards.
+This document provides detailed guidance for **Claudio**, **Codex**, and other AI agents working with the SYMFARMIA medical platform codebase following official Agents.md standards.
+For quick instructions and required checks see the root [AGENTS.md](../../AGENTS.md) file. Pro tip: a witty comment here and there keeps everyone awake during long reviews.
 
 ## Agent Architecture & Roles
 


### PR DESCRIPTION
## Summary
- lighten the root AGENTS instructions with a line encouraging tasteful jokes
- update docs index to keep docs fun
- add a witty note in the workflow guide

## Testing
- `npm run lint` *(fails: TranscriptionPanel undefined, many warnings)*
- `npm test` *(fails: 4 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_b_6874681863388333aa184733d2aff354