### PR TITLE
Improve Xenova Whisper integration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Welcome to the SYMFARMIA documentation hub. This directory contains all project 
 - [**I18n Implementation**](./development/REVOLUTIONARY-I18N-SUMMARY.md) - Internationalization features
 - [**Language Switcher**](./development/LANGUAGE-SWITCHER-SUMMARY.md) - Language switching functionality
 - [**Design Prompts**](./development/dalle-prompts.md) - AI-generated design prompts
+- [**Whisper Xenova Enhancements**](./development/whisper-xenova-enhancements.md) - Mejora de la precarga y reintentos
 
 #### Development Notes
 - [**Dev Notes**](./development/dev-notes/) - Daily development logs and notes

--- a/docs/development/whisper-xenova-enhancements.md
+++ b/docs/development/whisper-xenova-enhancements.md
@@ -1,0 +1,32 @@
+# 🤖 Whisper Xenova Enhancements
+
+La integración con `@xenova/transformers` ahora es más robusta.
+
+## ✨ Cambios Clave
+
+1. **Reintentos automáticos** al cargar el modelo con `retryCount` y `retryDelay`.
+2. **Precarga opcional** mediante el componente `WhisperPreloader` o la función `preloadModel` del hook.
+3. **Indicador de progreso** durante la descarga usando el parámetro `progress_callback` del pipeline.
+
+## 🚀 Uso Rápido
+
+```jsx
+import WhisperPreloader from '../domains/medical-ai/components/WhisperPreloader';
+
+// En la raíz de tu aplicación
+<WhisperPreloader retryCount={3} retryDelay={1000} />
+```
+
+Si prefieres controlar la carga manualmente:
+
+```javascript
+const { preloadModel, loadProgress } = useSimpleWhisper({ autoPreload: false });
+// Llama a preloadModel() cuando quieras iniciar la descarga
+```
+
+## 📁 Archivos Modificados
+
+- `useSimpleWhisper.js` ahora expone `preloadModel` y `loadProgress`.
+- Nuevo componente `WhisperPreloader.jsx` para realizar la precarga.
+
+Con estas mejoras, la experiencia de usuario es más fluida y se maneja mejor cualquier fallo de red.

--- a/src/domains/medical-ai/components/WhisperPreloader.jsx
+++ b/src/domains/medical-ai/components/WhisperPreloader.jsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { useSimpleWhisper } from '../hooks/useSimpleWhisper';
+
+/**
+ * WhisperPreloader Component
+ *
+ * Preloads the Xenova Whisper model outside of the main UI.
+ */
+export default function WhisperPreloader({ retryCount = 3, retryDelay = 1000 }) {
+  const { preloadModel, loadProgress, engineStatus } = useSimpleWhisper({
+    autoPreload: false,
+    retryCount,
+    retryDelay,
+  });
+
+  useEffect(() => {
+    preloadModel();
+  }, [preloadModel]);
+
+  if (engineStatus === 'loading') {
+    return (
+      <div className="p-2 text-sm text-gray-600">
+        Cargando modelo Whisper... {Math.round(loadProgress * 100)}%
+      </div>
+    );
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add retry logic and progress tracking to `useSimpleWhisper`
- expose a `preloadModel` function and new `WhisperPreloader` component
- document Xenova Whisper enhancements

## Testing
- `npm run lint --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68755d129ee08333aadf36fc153ab886