### PR TITLE
Fix missing demo transcription hook export

### DIFF
--- a/src/domains/demo/index.ts
+++ b/src/domains/demo/index.ts
@@ -16,7 +16,12 @@ export { DemoResetButton } from './components/DemoResetButton';
 
 // Hooks
 export { useDemoMode } from './hooks/useDemoMode';
-export { useDemoTranscription } from './hooks/useDemoTranscription';
+// Re-export demo transcription hook from the medical-ai legacy hooks.
+// The previous local hook file was removed during the medical AI refactor
+// but the public API still expects `useDemoTranscription` to be available
+// from this domain. Redirect to the maintained implementation to avoid
+// import errors during the build.
+export { useDemoTranscription } from '../medical-ai/hooks/legacy/useDemoTranscription';
 export { useDemoPatients } from './hooks/useDemoPatients';
 export { useDemoSettings } from './hooks/useDemoSettings';
 export { useDemoHighlight } from './hooks/useDemoHighlight';


### PR DESCRIPTION
## Summary
- re-export `useDemoTranscription` from the medical-ai legacy hooks to fix build error

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*
- `npm test` *(fails: existing tests fail to run)*

------
https://chatgpt.com/codex/tasks/task_b_687561c4e5c08333ad93b6c56d7ec2f1