### PR TITLE
Add SOAP note generation from transcriptions

### DIFF
--- a/app/consultation/page.tsx
+++ b/app/consultation/page.tsx
@@ -114,13 +114,6 @@ const ConsultationPage = () => {
     setShowPatientSelector(false);
   };
 
-  const handleTranscriptionComplete = (text: string) => {
-    setConsultationState(prev => ({
-      ...prev,
-      transcriptionText: text,
-      status: 'completed'
-    }));
-  };
 
 
   const handleSaveConsultation = async () => {
@@ -334,20 +327,7 @@ const ConsultationPage = () => {
             </div>
           </div>
 
-          {/* Transcription Panel */}
-          <TranscriptionPanel
-            specialty="general"
-            patientContext={{
-              patientId: selectedPatient?.id || '',
-              patientName: selectedPatient?.name || '',
-              age: selectedPatient?.age || 0,
-              medicalHistory: []
-            }}
-            onTranscriptionComplete={handleTranscriptionComplete}
-            className="mb-6"
-            medicalOptimization={true}
-            realTimeAnalysis={true}
-          />
+          {/* Transcription Panel (deprecated) */}
 
           {/* Quick Actions */}
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">


### PR DESCRIPTION
## Summary
- add SOAP generation methods to `medicalAIService`
- extend `useTranscription` hook with SOAP note support
- update `ConversationCaptureEnhanced` to display generated SOAP notes
- cleanup consultation page and integrate new hook

## Testing
- `npm run lint` *(fails: Calendar unused and other existing lint errors)*
- `npm test` *(fails: legacy design tests expect missing files)*

------
https://chatgpt.com/codex/tasks/task_b_68757e9fcd748333bebff455f230034e