### PR TITLE
Refactor audio pipeline with chunk manager

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -46,6 +46,9 @@ AI-generated design prompts:
 - Visual style guides
 - Design system elements
 
+### 🎤 [Audio Flow Overview](./audio-flow-overview.md)
+Summary of the unified audio capture and worker pipeline.
+
 ## 📁 Development Logs
 
 ### 📚 [Dev Notes](./dev-notes/)

--- a/docs/development/audio-flow-overview.md
+++ b/docs/development/audio-flow-overview.md
@@ -1,0 +1,11 @@
+# Audio Processing Flow
+
+This document summarizes the new audio capture architecture.
+
+1. **AudioChunkManager** collects raw audio data from `useAudioProcessor` and emits fixed-size chunks.
+2. **useUnifiedAudioCapture** uses the manager to start and stop recording, flushing remaining data on stop.
+3. **whisperModelCache** provides a single worker instance and exposes `sendMessage` and `addMessageListener` for communication.
+4. **useWhisperWorker** subscribes to the cache, sends chunks for processing and gathers results.
+5. **WhisperProvider** wraps `useSimpleWhisper` and exposes high-level controls via React context.
+
+With this flow, audio moves cleanly from capture to transcription, reducing the risk of stack overflows from recursive listeners.

--- a/src/domains/medical-ai/audio/AudioChunkManager.ts
+++ b/src/domains/medical-ai/audio/AudioChunkManager.ts
@@ -1,0 +1,56 @@
+export type ChunkCallback = (chunk: Float32Array, chunkId: number) => void;
+
+export interface AudioChunkManagerOptions {
+  chunkSize: number;
+  onChunk: ChunkCallback;
+}
+
+export class AudioChunkManager {
+  private buffers: Float32Array[] = [];
+  private chunkSize: number;
+  private onChunk: ChunkCallback;
+  private chunkCount = 0;
+
+  constructor(options: AudioChunkManagerOptions) {
+    this.chunkSize = options.chunkSize;
+    this.onChunk = options.onChunk;
+  }
+
+  addData(data: Float32Array) {
+    this.buffers.push(data);
+    const total = this.buffers.reduce((sum, b) => sum + b.length, 0);
+
+    if (total >= this.chunkSize) {
+      const combined = new Float32Array(total);
+      let offset = 0;
+      for (const b of this.buffers) {
+        combined.set(b, offset);
+        offset += b.length;
+      }
+      const chunk = combined.slice(0, this.chunkSize);
+      const remaining = combined.slice(this.chunkSize);
+      this.buffers = remaining.length ? [remaining] : [];
+      this.chunkCount += 1;
+      this.onChunk(chunk, this.chunkCount);
+    }
+  }
+
+  flush() {
+    const total = this.buffers.reduce((s, b) => s + b.length, 0);
+    if (total > 0) {
+      const combined = new Float32Array(total);
+      let offset = 0;
+      for (const b of this.buffers) {
+        combined.set(b, offset);
+        offset += b.length;
+      }
+      this.chunkCount += 1;
+      this.onChunk(combined, this.chunkCount);
+      this.buffers = [];
+    }
+  }
+
+  get count() {
+    return this.chunkCount;
+  }
+}

--- a/src/domains/medical-ai/context/WhisperProvider.tsx
+++ b/src/domains/medical-ai/context/WhisperProvider.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext } from 'react';
+import { useSimpleWhisper } from '../hooks/useSimpleWhisper';
+
+interface WhisperContextValue {
+  startTranscription: () => Promise<boolean>;
+  stopTranscription: () => Promise<boolean>;
+  resetTranscription: () => void;
+  transcription: string | null;
+  status: string;
+}
+
+const WhisperContext = createContext<WhisperContextValue | undefined>(undefined);
+
+export const WhisperProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const whisper = useSimpleWhisper();
+
+  return (
+    <WhisperContext.Provider
+      value={{
+        startTranscription: whisper.startTranscription,
+        stopTranscription: whisper.stopTranscription,
+        resetTranscription: whisper.resetTranscription,
+        transcription: whisper.transcription?.text || null,
+        status: whisper.status
+      }}
+    >
+      {children}
+    </WhisperContext.Provider>
+  );
+};
+
+export const useWhisper = (): WhisperContextValue => {
+  const ctx = useContext(WhisperContext);
+  if (!ctx) throw new Error('useWhisper must be used within WhisperProvider');
+  return ctx;
+};

--- a/src/domains/medical-ai/services/whisperModelCache.ts
+++ b/src/domains/medical-ai/services/whisperModelCache.ts
@@ -154,6 +154,11 @@ class WhisperModelCache {
       this.listeners.delete(listener);
     };
   }
+
+  sendMessage(message: any, transfer?: Transferable[]) {
+    if (!this.worker) throw new Error('Worker not initialized');
+    this.worker.postMessage(message, transfer || []);
+  }
   
   isModelLoaded(): boolean {
     return this.modelLoaded;


### PR DESCRIPTION
## Summary
- introduce `AudioChunkManager` for clean chunk creation
- simplify `useUnifiedAudioCapture` with the manager
- add `sendMessage` API in `whisperModelCache`
- update `useWhisperWorker` to use cache for messaging
- provide `WhisperProvider` context wrapper
- document the new flow in `audio-flow-overview.md`

## Testing
- `npm run lint` *(fails: 'WhisperDebugPanel' is defined but never used, etc.)*
- `npm test` *(fails to run some legacy design tests)*

------
https://chatgpt.com/codex/tasks/task_b_6878312a75948333b9a800dd35200c14